### PR TITLE
Sphinx fixes

### DIFF
--- a/cookbooks/sphinx/templates/default/sphinx.monitrc.erb
+++ b/cookbooks/sphinx/templates/default/sphinx.monitrc.erb
@@ -1,6 +1,6 @@
 check process sphinx_<%= @app_name %>_9312
   with pidfile /var/run/sphinx/<%= @app_name %>.pid
-  start program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> start" as uid <%= @user %> and gid <%= @user %>
-  stop program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> stop" as uid <%= @user %> and gid <%= @user %>
+  start program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> start <%= @node[:environment][:framework_env] %>" as uid <%= @user %> and gid <%= @user %>
+  stop program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> stop <%= @node[:environment][:framework_env] %>" as uid <%= @user %> and gid <%= @user %>
   group sphinx_<%= @app_name %>
 


### PR DESCRIPTION
Two commits here.

The first updates the sphinx monit group template to use 9312 in the name instead of 3312 as the default port of searchd is 9312. So the monit group will now read "sphinx_appname_9312".

The second commit modifies the same template and passes the environment as the third argument to the searchd command for starting and stopping. Without this, in an environment other than production, monit fails to start searchd and searchd logs the error "production database is not configured".
