### PR TITLE
fix for emerge cookbook, enable_package definition:  don't modify name at

### DIFF
--- a/cookbooks/emerge/definitions/enable_package.rb
+++ b/cookbooks/emerge/definitions/enable_package.rb
@@ -1,7 +1,7 @@
 define :enable_package, :version => nil do
   name = params[:name]
   version = params[:version]
-  full_name = name << ("-#{version}" if version)
+  full_name = name + ("-#{version}" if version)
 
   update_file "local portage package.keywords" do
     path "/etc/portage/package.keywords/local"


### PR DESCRIPTION
fix for emerge cookbook, enable_package definition:  don't modify name attribute string.

got bitten by this earlier today when iterating over a package_name, version array where I was attempting to just use the package name later on in the recipe
