### PR TITLE
Use the correct hostname when sphinx is running on util slice

### DIFF
--- a/cookbooks/sphinx/recipes/default.rb
+++ b/cookbooks/sphinx/recipes/default.rb
@@ -30,6 +30,7 @@ utility_name = nil
 cron_interval = nil #If this is not set your data will NOT be indexed
 
 if utility_name
+  sphinx_host = node[:utility_instances].find {|u| u[:name] == utility_name }[:hostname]
   if ['solo', 'app', 'app_master'].include?(node[:instance_role])
     run_for_app(appname) do |app_name, data|
       ey_cloud_report "Sphinx" do
@@ -50,6 +51,7 @@ if utility_name
         source "sphinx.yml.erb"
         variables({
           :app_name => app_name,
+          :address => sphinx_host,
           :user => node[:owner_name],
           :mem_limit => 32
         })
@@ -111,6 +113,7 @@ if utility_name
         source "sphinx.yml.erb"
         variables({
           :app_name => app_name,
+          :address => 'localhost',
           :user => node[:owner_name],
           :mem_limit => 32
         })
@@ -212,6 +215,7 @@ else
         source "sphinx.yml.erb"
         variables({
           :app_name => app_name,
+          :address => 'localhost',
           :user => node[:owner_name],
           :mem_limit => 32
         })

--- a/cookbooks/sphinx/templates/default/sphinx.yml.erb
+++ b/cookbooks/sphinx/templates/default/sphinx.yml.erb
@@ -2,7 +2,7 @@
   searchd_log_file: /var/log/engineyard/sphinx/<%= @app_name %>/searchd.log
   query_log_file: /var/log/engineyard/sphinx/<%= @app_name %>/query.log
   pid_file: /var/run/sphinx/<%= @app_name %>.pid
-  address: localhost
+  address: <%= @address %>
   port: 9312
   mem_limit: <%= @mem_limit %>
   config_file: /data/<%= @app_name %>/current/config/sphinx/<%= @node[:environment][:framework_env] %>.sphinx.conf


### PR DESCRIPTION
Currently, when you set sphinx to run on a util slice, the address
in sphinx.yml is hardcoded to point to localhost. Obviously, this
wont work. Altered the config and recipe to use the sphinx util
slice hostname as the address, and still maintain localhost for the
util slice sphinx.yml
