### PR TITLE
Higher sphinx timeout to give enough time for rails to start

### DIFF
--- a/cookbooks/sphinx/templates/default/sphinx.monitrc.erb
+++ b/cookbooks/sphinx/templates/default/sphinx.monitrc.erb
@@ -1,5 +1,5 @@
 check process sphinx_<%= @app_name %>_9312
   with pidfile /var/run/sphinx/<%= @app_name %>.pid
-  start program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> start <%= @env %>" as uid <%= @user %> and gid <%= @user %>
-  stop program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> stop <%= @env %>" as uid <%= @user %> and gid <%= @user %>
+  start program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> start <%= @env %>" as uid <%= @user %> and gid <%= @user %> with timeout 90 seconds
+  stop program = "/engineyard/bin/<%= @flavor %>_searchd <%= @app_name %> stop <%= @env %>" as uid <%= @user %> and gid <%= @user %> with timeout 90 seconds
   group sphinx_<%= @app_name %>


### PR DESCRIPTION
Updating sphinx timeout to 90 seconds instead of the default 30. We have a relatively small app that take a bit more than 30 seconds to load (1.9.2 is slow). This fixes the "execution expired" error for slow loading apps.
