### PR TITLE
Add high memory instances to jruby default recipe

### DIFF
--- a/cookbooks/jruby/recipes/default.rb
+++ b/cookbooks/jruby/recipes/default.rb
@@ -34,31 +34,51 @@ APP_DIRECTORY = '/data/hello_world/current'
 
 size = `curl -s http://instance-data.ec2.internal/latest/meta-data/instance-type`
 case size
-when /m1.small/ # 1.7G RAM, 1 ECU, 32-bit
-  JVM_CONFIG = '-server -Xmx1g -Xms1g -XX:MaxPermSize=256m -XX:PermSize=256m -XX:NewRatio=2 -XX:+DisableExplicitGC'
+when /t1.micro/ # 0.6G RAM, 1 ECU, 32- or 64-bit  ## should never use micros but set defaults just in case 
+  JVM_CONFIG = '-server -Xmx512m -Xms512m -XX:MaxPermSize=128m -XX:PermSize=128m -XX:NewRatio=2 -XX:+DisableExplicitGC'
   JRUBY_RUNTIME_POOL_INITIAL = 1
   JRUBY_RUNTIME_POOL_MIN = 1
   JRUBY_RUNTIME_POOL_MAX = 1
-when /m1.large/ # 1.7G RAM, 5 ECU, 32-bit
-  JVM_CONFIG = '-server -Xmx1g -Xms1g -XX:MaxPermSize=256m -XX:PermSize=256m -XX:NewRatio=2 -XX:+DisableExplicitGC'
+when /m1.small/ # 1.7G RAM, 1 ECU, 32-bit
+  JVM_CONFIG = '-server -Xmx1g -Xms512m -XX:MaxPermSize=256m -XX:PermSize=256m -XX:NewRatio=2 -XX:+DisableExplicitGC'
   JRUBY_RUNTIME_POOL_INITIAL = 1
   JRUBY_RUNTIME_POOL_MIN = 1
-  JRUBY_RUNTIME_POOL_MAX = 5
-when /m1.xlarge/ # 7.5G RAM, 4 ECU, 64-bit
-  JVM_CONFIG = '-server -Xmx2.5g -Xms2.5g -XX:MaxPermSize=378m -XX:PermSize=378m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_MAX = 1
+when /m1.large/ # 7.5G RAM, 4 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx2g -Xms512m -XX:MaxPermSize=256m -XX:PermSize=256m -XX:NewRatio=2 -XX:+DisableExplicitGC'
   JRUBY_RUNTIME_POOL_INITIAL = 1
   JRUBY_RUNTIME_POOL_MIN = 1
-  JRUBY_RUNTIME_POOL_MAX = 5
-when /c1.medium/ # 15G RAM, 8 ECU, 64-bit
-  JVM_CONFIG = '-server -Xmx2.5g -Xms2.5g -XX:MaxPermSize=378m -XX:PermSize=378m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_MAX = 4
+when /m1.xlarge/ # 15G RAM, 8 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx2.5g -Xms512m -XX:MaxPermSize=378m -XX:PermSize=378m =XX:NewRatio=2'
   JRUBY_RUNTIME_POOL_INITIAL = 1
   JRUBY_RUNTIME_POOL_MIN = 1
   JRUBY_RUNTIME_POOL_MAX = 8
-when /c1.xlarge/ # 7.5G RAM, 20 ECU, 64-bit
-  JVM_CONFIG = '-server -Xmx2.5g -Xms2.5g -XX:MaxPermSize=378m -XX:PermSize=378m =XX:NewRatio=2'
+when /c1.medium/ # 1.7G RAM, 5 ECU, 32-bit
+  JVM_CONFIG = '-server -Xmx1g -Xms512m -XX:MaxPermSize=256m -XX:PermSize=256m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_INITIAL = 1
+  JRUBY_RUNTIME_POOL_MIN = 1
+  JRUBY_RUNTIME_POOL_MAX = 5
+when /c1.xlarge/ # 7.0G RAM, 20 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx4g -Xms512m -XX:MaxPermSize=1024m -XX:PermSize=512m =XX:NewRatio=2'
   JRUBY_RUNTIME_POOL_INITIAL = 1
   JRUBY_RUNTIME_POOL_MIN = 1
   JRUBY_RUNTIME_POOL_MAX = 20
+when /m2.xlarge/ # 17.1G RAM, 6.5 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx4g -Xms512m -XX:MaxPermSize=1024m -XX:PermSize=512m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_INITIAL = 1
+  JRUBY_RUNTIME_POOL_MIN = 1
+  JRUBY_RUNTIME_POOL_MAX = 8
+when /m2.2xlarge/ # 34.2G RAM, 13 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx4g -Xms512m -XX:MaxPermSize=1024m -XX:PermSize=512m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_INITIAL = 1
+  JRUBY_RUNTIME_POOL_MIN = 1
+  JRUBY_RUNTIME_POOL_MAX = 8
+when /m2.4xlarge/ # 68G RAM, 26 ECU, 64-bit
+  JVM_CONFIG = '-server -Xmx4g -Xms512m -XX:MaxPermSize=1024m -XX:PermSize=512m =XX:NewRatio=2'
+  JRUBY_RUNTIME_POOL_INITIAL = 1
+  JRUBY_RUNTIME_POOL_MIN = 1
+  JRUBY_RUNTIME_POOL_MAX = 8
 else # This shouldn't happen, but do something rational if it does.
   JVM_CONFIG = '-server -Xmx1g -Xms1g -XX:MaxPermSize=256m -XX:PermSize=256m -XX:NewRatio=2 -XX:+DisableExplicitGC'
   JRUBY_RUNTIME_POOL_INITIAL = 1


### PR DESCRIPTION
Could use feedback from David Calavera as to whether the JRUBY_RUNTIME_POOL values are sensible. Do we want all 1's as the default? 
