### PR TITLE
Modify JAVA_OPTS call so that it actually uses the memory/heap settings

### DIFF
--- a/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
@@ -28,7 +28,7 @@ JAVA_OPTS="$JAVA_OPTS -Djline.enabled=true"
 #JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedOops"
 
 # This stops an annoying warning
-JAVA_OPTS="-server"
+JAVA_OPTS="$JAVA_OPTS -server"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+CMSParallelRemarkEnabled"


### PR DESCRIPTION
This was causing my production box to quickly run out of memory.
