### PR TITLE
Bumps Riak to 1.1.2 and fixes error with haproxy.conf

### DIFF
--- a/cookbooks/riak/README.md
+++ b/cookbooks/riak/README.md
@@ -19,7 +19,7 @@ Design
 
 * 3+ utility instances 64-bit (m1.large +) running 
 
-* Riak 1.0.2 w/ defaults to leveldb
+* Riak 1.1.2 w/ defaults to leveldb
 * Erlang R140B3 (installed from a custom binary package)
 * haproxy is configured on 8097-8098 (pbc,http) with the http back-end using /ping to ensure the back-end is up.
 

--- a/cookbooks/riak/attributes/riak.rb
+++ b/cookbooks/riak/attributes/riak.rb
@@ -1,1 +1,14 @@
-riak :version => "1.0.3", :data_root => "/data/riak/data", :map_js_vm_count => "8", :reduce_js_vm_count => "6", :hook_js_vm_count => "2", :js_max_vm_mem => "8", :js_thread_stack => "16", :riak_kv_stat => "true", :legacy_stats => "false", :legacy_keylisting => "false", :luwak_enabled => "false", :riaksearch_enabled => "false", :backend_enabled => "riak_kv_eleveldb_backend", :pb_backlog => "64"
+riak :version => "1.1.2",
+     :data_root => "/data/riak/data",
+     :map_js_vm_count => "8",
+     :reduce_js_vm_count => "6",
+     :hook_js_vm_count => "2",
+     :js_max_vm_mem => "8",
+     :js_thread_stack => "16",
+     :riak_kv_stat => "true",
+     :legacy_stats => "false",
+     :legacy_keylisting => "false",
+     :luwak_enabled => "false",
+     :riaksearch_enabled => "false",
+     :backend_enabled => "riak_kv_eleveldb_backend",
+     :pb_backlog => "64"

--- a/cookbooks/riak/recipes/haproxy.rb
+++ b/cookbooks/riak/recipes/haproxy.rb
@@ -11,9 +11,8 @@ else
       action :upgrade
     end
 
-    riak_instances = []
-    riak_instances << node["engineyard"]["environment"]["instances"].map{|x| x["private_hostname"] if x["name"] =~ /^riak_/ }.compact
-    
+    riak_instances = node["engineyard"]["environment"]["instances"].map{|x| x["private_hostname"] if x["name"] =~ /^riak_/ }.compact
+
     template "/etc/haproxy_riak.cfg" do
       owner 'root'
       group 'root'
@@ -25,7 +24,6 @@ else
         :haproxy_pass => node[:haproxy][:password]
       })
     end
-    
     template "/etc/monit.d/haproxy_riak.monitrc" do
       source "haproxy_monitrc.erb"
       backup 0


### PR DESCRIPTION
Recipe now correctly list riak nodes in haproxy.conf. 
We have also bumped Riak to version 1.1.2
