### PR TITLE
CC-32 - ssmtp configs should be symlinked on util instances also

### DIFF
--- a/cookbooks/ssmtp/recipes/default.rb
+++ b/cookbooks/ssmtp/recipes/default.rb
@@ -4,7 +4,7 @@ require 'pp'
 # Recipe:: default
 #
 
-if ['solo', 'app', 'app_master'].include?(node[:instance_role])
+if ['solo', 'app', 'util', 'app_master'].include?(node[:instance_role])
 
   directory "/etc/ssmtp" do
     recursive true


### PR DESCRIPTION
Update to support ssmtp on util instances

QA - To test:
1. enable ssmtp recipe in custom cookbooks, attach to environment
2. Boot environment (or add a utility instance)
3. Verify /etc/ssmtp is a symlink to /data/ssmtp

(Instance that use exim or postfix should still have the symlink as this only affects the config location (stored on EBS)) 
