### PR TITLE
Add "override_hardmask true" option to "enable_package"

### DIFF
--- a/cookbooks/emerge/definitions/enable_package.rb
+++ b/cookbooks/emerge/definitions/enable_package.rb
@@ -8,18 +8,21 @@ define :enable_package, :version => nil, :override_hardmask => false do
   end
 
   # won't override a hard-mask
-  update_file "add #{full_name} to package.keywords" do
+  p = "/etc/portage/package.keywords/local"
+  update_file "add #{full_name} to #{p}" do
     action :append
-    path "/etc/portage/package.keywords/local"
+    path p
     body "=#{full_name}"
-    not_if "grep '=#{full_name}' /etc/portage/package.keywords/local"
+    not_if "grep '=#{full_name}' #{p}"
   end
 
   if params[:override_hardmask]
-    update_file "add #{full_name} to package.unmask" do
-      action :rewrite
-      path "/etc/portage/package.unmask/#{full_name.gsub(/\W/, '_')}"
+    p = "/etc/portage/package.unmask/engineyard_overrides"
+    update_file "add #{full_name} to #{p}" do
+      action :append
+      path p
       body "=#{full_name}"
+      not_if "grep '=#{full_name}' #{p}"
     end
   end
 end


### PR DESCRIPTION
Sometimes just adding a package to package.keywords isn't enough... so this allows:

```
enable_package 'app-admin/syslog-ng' do
  version '3.3.5'
  override_hardmask true # this
end
```

and it will create `/etc/portage/package.unmask/app_admin_syslog_ng_3_3_5` with one line in it:

```
=app-admin/syslog-ng-3.3.5
```
