### PR TITLE
Added recipe to share database.yml between applications

### DIFF
--- a/cookbooks/shared_db/README.md
+++ b/cookbooks/shared_db/README.md
@@ -1,0 +1,11 @@
+# Shared Database
+
+This recipe symlinks the `database.yml` from one application to another in a
+multiple-application environment.
+
+## Usage
+
+Modify the `app` and `parent_app` variables in the default recipe then require
+it in the `cookbooks/main/recipes/default.rb`.
+
+    require_recipe "shared_db"

--- a/cookbooks/shared_db/metadata.rb
+++ b/cookbooks/shared_db/metadata.rb
@@ -1,0 +1,5 @@
+description 'Symlink the database.yml file from one app to another'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'info@engineyard.com'
+version '0.0.1'

--- a/cookbooks/shared_db/recipes/default.rb
+++ b/cookbooks/shared_db/recipes/default.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: shared_db
+# Recipe:: default
+#
+# Adapted from https://github.com/omgitsads/ey-cloud-recipes/blob/shared-db/cookbooks/shared-db/recipes/default.rb
+# by Adam Holt (@omgitsads)
+#
+
+# Name of the application
+app = "myapp"
+app_path = "/data/#{app}/shared/config/database.yml"
+
+# The name of the application with db credentials you want to use
+parent_app = "parentapp"
+parent_app_path = "/data/#{parent_app}/shared/config/database.yml"
+
+if app && parent_app
+  execute "Symlink #{parent_app_path} to #{app_path}" do
+    command "ln -sf #{parent_app_path} #{app_path}"
+    only_if "test -f #{parent_app_path}"
+  end
+end


### PR DESCRIPTION
This recipe basically just symlinks the `database.yml` file from one application to another in a multi-app environment.
