### PR TITLE
Fix resque recipe indendataion

### DIFF
--- a/cookbooks/resque/recipes/default.rb
+++ b/cookbooks/resque/recipes/default.rb
@@ -10,16 +10,15 @@ if ['solo', 'util'].include?(node[:instance_role])
   end
 
   case node[:ec2][:instance_type]
-    when 'm1.small': worker_count = 2
-    when 'c1.medium': worker_count = 3
-    when 'c1.xlarge': worker_count = 8
-      else 
-        worker_count = 4
-    end
-  
+  when 'm1.small': worker_count = 2
+  when 'c1.medium': worker_count = 3
+  when 'c1.xlarge': worker_count = 8
+  else worker_count = 4
+  end
 
-    node[:applications].each do |app, data|
-      template "/etc/monit.d/resque_#{app}.monitrc" do 
+
+  node[:applications].each do |app, data|
+    template "/etc/monit.d/resque_#{app}.monitrc" do
       owner 'root' 
       group 'root' 
       mode 0644 
@@ -29,16 +28,16 @@ if ['solo', 'util'].include?(node[:instance_role])
       :app_name => app, 
       :rails_env => node[:environment][:framework_env] 
       }) 
-      end
+    end
 
-      worker_count.times do |count|
-        template "/data/#{app}/shared/config/resque_#{count}.conf" do
+    worker_count.times do |count|
+      template "/data/#{app}/shared/config/resque_#{count}.conf" do
         owner node[:owner_name]
         group node[:owner_name]
         mode 0644
         source "resque_wildcard.conf.erb"
-        end
       end
+    end
 
     execute "ensure-resque-is-setup-with-monit" do 
       epic_fail true


### PR DESCRIPTION
The indentation in cookbooks/resque/recipes/default.rb was all messed up, which was confusing and caused me to inadvertently add a syntax error while I was editing. I understand that these "cosmetic" changes have the potential to conflict with many others' forked changes, and I don't take this lightly. I do however think that it's pretty unclear which blocks are intended to be inside the loop with the broken indentation.
