### PR TITLE
Added 1.9.3 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - '1.8.7'
+  - '1.9.3'


### PR DESCRIPTION
Pretty self-explanatory, just adds 1.9.3 to the `.travis.yml` file so that tests will run on that version as well.
