### PR TITLE
Fix docs for timezone recipe - DOC-782

### DIFF
--- a/cookbooks/timezone/README.md
+++ b/cookbooks/timezone/README.md
@@ -1,6 +1,8 @@
 # Changing the Timezone
 
-This cookbook makes it easy to change the timezone of an instance to one that suits your geographical location, rather than the default PST zone.
+This cookbook makes it easy to change the timezone of an instance to one that suits your geographical location, rather than the default UTC zone.
+
+NOTE: Older instances on Engine Yard Cloud use(d) the PST time zone by default. We've made changes to our stack to default to UTC in an effort to better standardize our product, and any new instances launched will default to UTC.
 
 
 ## Installation


### PR DESCRIPTION
The timezone recipe readme mentions the old PST default when it's in fact changed to UTC now. I've updated the readme to reflect that change and better explain the differences. No code changes.
