### PR TITLE
Guard sphinx recipe so it can run before deploy

### DIFF
--- a/cookbooks/sphinx/recipes/default.rb
+++ b/cookbooks/sphinx/recipes/default.rb
@@ -29,247 +29,252 @@ utility_name = nil
 
 cron_interval = nil #If this is not set your data will NOT be indexed
 
-if utility_name
-  sphinx_host = node[:utility_instances].find {|u| u[:name] == utility_name }[:hostname]
-  if ['solo', 'app', 'app_master'].include?(node[:instance_role])
-    run_for_app(appname) do |app_name, data|
-      ey_cloud_report "Sphinx" do
-        message "configuring #{flavor}"
-      end
 
-      directory "/data/#{app_name}/shared/config/sphinx" do
-        recursive true
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
+if ! File.exists?("/data/#{appname}/current")
+  Chef::Log.info "Sphinx was not configured because the app must be deployed first.  Please deploy it then re-run custom recipes."
+else
+  if utility_name
+    sphinx_host = node[:utility_instances].find {|u| u[:name] == utility_name }[:hostname]
+    if ['solo', 'app', 'app_master'].include?(node[:instance_role])
+      run_for_app(appname) do |app_name, data|
+        ey_cloud_report "Sphinx" do
+          message "configuring #{flavor}"
+        end
 
-      template "/data/#{app_name}/shared/config/sphinx.yml" do
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0644
-        source "sphinx.yml.erb"
-        variables({
-          :app_name => app_name,
-          :address => sphinx_host,
-          :user => node[:owner_name],
-          :mem_limit => '32M'
-        })
-      end
-    end
-  end
+        directory "/data/#{app_name}/shared/config/sphinx" do
+          recursive true
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
 
-  if node[:name] == utility_name
-    run_for_app(appname) do |app_name, data|
-      ey_cloud_report "Sphinx" do
-        message "configuring #{flavor}"
-      end
-
-      directory "/var/run/sphinx" do
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
-
-      directory "/var/log/engineyard/sphinx/#{app_name}" do
-        recursive true
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
-
-      directory "/data/#{app_name}/shared/config/sphinx" do
-        recursive true
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
-
-      remote_file "/etc/logrotate.d/sphinx" do
-        owner "root"
-        group "root"
-        mode 0755
-        source "sphinx.logrotate"
-        backup false
-        action :create
-      end
-
-      template "/etc/monit.d/sphinx.#{app_name}.monitrc" do
-        source "sphinx.monitrc.erb"
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0644
-        variables({
-          :app_name => app_name,
-          :user => node[:owner_name],
-          :flavor => flavor
-        })
-      end
-
-      template "/data/#{app_name}/shared/config/sphinx.yml" do
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0644
-        source "sphinx.yml.erb"
-        variables({
-          :app_name => app_name,
-          :address => sphinx_host,
-          :user => node[:owner_name],
-          :mem_limit => '32M'
-        })
-      end
-
-      gem_package "bundler" do 
-        source "http://rubygems.org" 
-        action :install 
-        version "1.0.21" 
-      end
-
-      execute "sphinx config" do
-        command "bundle exec rake #{flavor}:configure"
-        user node[:owner_name]
-        environment({
-          'HOME' => "/home/#{node[:owner_name]}",
-          'RAILS_ENV' => node[:environment][:framework_env]
-        })
-        cwd "/data/#{app_name}/current"
-      end
-
-      ey_cloud_report "indexing #{flavor}" do
-        message "indexing #{flavor}"
-      end
-
-      execute "#{flavor} index" do
-        command "bundle exec rake #{flavor}:index"
-        user node[:owner_name]
-        environment({
-          'HOME' => "/home/#{node[:owner_name]}",
-          'RAILS_ENV' => node[:environment][:framework_env]
-        })
-        cwd "/data/#{app_name}/current"
-      end
-
-      execute "monit reload"
-
-      if cron_interval
-        cron "sphinx index" do
-          action  :create
-          minute  "*/#{cron_interval}"
-          hour    '*'
-          day     '*'
-          month   '*'
-          weekday '*'
-          command "cd /data/#{app_name}/current && RAILS_ENV=#{node[:environment][:framework_env]} bundle exec rake #{flavor}:index"
-          user node[:owner_name]
+        template "/data/#{app_name}/shared/config/sphinx.yml" do
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0644
+          source "sphinx.yml.erb"
+          variables({
+            :app_name => app_name,
+            :address => sphinx_host,
+            :user => node[:owner_name],
+            :mem_limit => '32M'
+          })
         end
       end
     end
-  end
-else
-  if ['solo', 'app', 'app_master'].include?(node[:instance_role])
-    run_for_app(appname) do |app_name, data|
-      ey_cloud_report "Sphinx" do
-        message "configuring #{flavor}"
-      end
 
-      directory "/var/run/sphinx" do
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
+    if node[:name] == utility_name
+      run_for_app(appname) do |app_name, data|
+        ey_cloud_report "Sphinx" do
+          message "configuring #{flavor}"
+        end
 
-      directory "/var/log/engineyard/sphinx/#{app_name}" do
-        recursive true
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
+        directory "/var/run/sphinx" do
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
 
-      directory "/data/#{app_name}/shared/config/sphinx" do
-        recursive true
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0755
-      end
+        directory "/var/log/engineyard/sphinx/#{app_name}" do
+          recursive true
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
 
-      remote_file "/etc/logrotate.d/sphinx" do
-        owner "root"
-        group "root"
-        mode 0755
-        source "sphinx.logrotate"
-        backup false
-        action :create
-      end
+        directory "/data/#{app_name}/shared/config/sphinx" do
+          recursive true
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
 
-      template "/etc/monit.d/sphinx.#{app_name}.monitrc" do
-        source "sphinx.monitrc.erb"
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0644
-        variables({
-          :app_name => app_name,
-          :user => node[:owner_name],
-          :env => node[:environment][:framework_env],
-          :flavor => flavor
-        })
-      end
+        remote_file "/etc/logrotate.d/sphinx" do
+          owner "root"
+          group "root"
+          mode 0755
+          source "sphinx.logrotate"
+          backup false
+          action :create
+        end
 
-      template "/data/#{app_name}/shared/config/sphinx.yml" do
-        owner node[:owner_name]
-        group node[:owner_name]
-        mode 0644
-        source "sphinx.yml.erb"
-        variables({
-          :app_name => app_name,
-          :address => 'localhost',
-          :user => node[:owner_name],
-          :mem_limit => '32'
-        })
-      end
+        template "/etc/monit.d/sphinx.#{app_name}.monitrc" do
+          source "sphinx.monitrc.erb"
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0644
+          variables({
+            :app_name => app_name,
+            :user => node[:owner_name],
+            :flavor => flavor
+          })
+        end
 
-      gem_package "bundler" do 
-        source "http://rubygems.org" 
-        action :install 
-        version "1.0.21" 
-      end
+        template "/data/#{app_name}/shared/config/sphinx.yml" do
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0644
+          source "sphinx.yml.erb"
+          variables({
+            :app_name => app_name,
+            :address => sphinx_host,
+            :user => node[:owner_name],
+            :mem_limit => '32M'
+          })
+        end
 
+        gem_package "bundler" do 
+          source "http://rubygems.org" 
+          action :install 
+          version "1.0.21" 
+        end
 
-      execute "sphinx config" do
-        command "bundle exec rake #{flavor}:configure"
-        user node[:owner_name]
-        environment({
-          'HOME' => "/home/#{node[:owner_name]}",
-          'RAILS_ENV' => node[:environment][:framework_env]
-        })
-        cwd "/data/#{app_name}/current"
-      end
-
-      ey_cloud_report "indexing #{flavor}" do
-        message "indexing #{flavor}"
-      end
-
-      execute "#{flavor} index" do
-        command "bundle exec rake #{flavor}:index"
-        user node[:owner_name]
-        environment({
-          'HOME' => "/home/#{node[:owner_name]}",
-          'RAILS_ENV' => node[:environment][:framework_env]
-        })
-        cwd "/data/#{app_name}/current"
-      end
-
-      execute "monit reload"
-
-      if cron_interval
-        cron "sphinx index" do
-          action  :create
-          minute  "*/#{cron_interval}"
-          hour    '*'
-          day     '*'
-          month   '*'
-          weekday '*'
-          command "cd /data/#{app_name}/current && RAILS_ENV=#{node[:environment][:framework_env]} bundle exec rake #{flavor}:index"
+        execute "sphinx config" do
+          command "bundle exec rake #{flavor}:configure"
           user node[:owner_name]
+          environment({
+            'HOME' => "/home/#{node[:owner_name]}",
+            'RAILS_ENV' => node[:environment][:framework_env]
+          })
+          cwd "/data/#{app_name}/current"
+        end
+
+        ey_cloud_report "indexing #{flavor}" do
+          message "indexing #{flavor}"
+        end
+
+        execute "#{flavor} index" do
+          command "bundle exec rake #{flavor}:index"
+          user node[:owner_name]
+          environment({
+            'HOME' => "/home/#{node[:owner_name]}",
+            'RAILS_ENV' => node[:environment][:framework_env]
+          })
+          cwd "/data/#{app_name}/current"
+        end
+
+        execute "monit reload"
+
+        if cron_interval
+          cron "sphinx index" do
+            action  :create
+            minute  "*/#{cron_interval}"
+            hour    '*'
+            day     '*'
+            month   '*'
+            weekday '*'
+            command "cd /data/#{app_name}/current && RAILS_ENV=#{node[:environment][:framework_env]} bundle exec rake #{flavor}:index"
+            user node[:owner_name]
+          end
+        end
+      end
+    end
+  else
+    if ['solo', 'app', 'app_master'].include?(node[:instance_role])
+      run_for_app(appname) do |app_name, data|
+        ey_cloud_report "Sphinx" do
+          message "configuring #{flavor}"
+        end
+
+        directory "/var/run/sphinx" do
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
+
+        directory "/var/log/engineyard/sphinx/#{app_name}" do
+          recursive true
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
+
+        directory "/data/#{app_name}/shared/config/sphinx" do
+          recursive true
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0755
+        end
+
+        remote_file "/etc/logrotate.d/sphinx" do
+          owner "root"
+          group "root"
+          mode 0755
+          source "sphinx.logrotate"
+          backup false
+          action :create
+        end
+
+        template "/etc/monit.d/sphinx.#{app_name}.monitrc" do
+          source "sphinx.monitrc.erb"
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0644
+          variables({
+            :app_name => app_name,
+            :user => node[:owner_name],
+            :env => node[:environment][:framework_env],
+            :flavor => flavor
+          })
+        end
+
+        template "/data/#{app_name}/shared/config/sphinx.yml" do
+          owner node[:owner_name]
+          group node[:owner_name]
+          mode 0644
+          source "sphinx.yml.erb"
+          variables({
+            :app_name => app_name,
+            :address => 'localhost',
+            :user => node[:owner_name],
+            :mem_limit => '32'
+          })
+        end
+
+        gem_package "bundler" do 
+          source "http://rubygems.org" 
+          action :install 
+          version "1.0.21" 
+        end
+
+
+        execute "sphinx config" do
+          command "bundle exec rake #{flavor}:configure"
+          user node[:owner_name]
+          environment({
+            'HOME' => "/home/#{node[:owner_name]}",
+            'RAILS_ENV' => node[:environment][:framework_env]
+          })
+          cwd "/data/#{app_name}/current"
+        end
+
+        ey_cloud_report "indexing #{flavor}" do
+          message "indexing #{flavor}"
+        end
+
+        execute "#{flavor} index" do
+          command "bundle exec rake #{flavor}:index"
+          user node[:owner_name]
+          environment({
+            'HOME' => "/home/#{node[:owner_name]}",
+            'RAILS_ENV' => node[:environment][:framework_env]
+          })
+          cwd "/data/#{app_name}/current"
+        end
+
+        execute "monit reload"
+
+        if cron_interval
+          cron "sphinx index" do
+            action  :create
+            minute  "*/#{cron_interval}"
+            hour    '*'
+            day     '*'
+            month   '*'
+            weekday '*'
+            command "cd /data/#{app_name}/current && RAILS_ENV=#{node[:environment][:framework_env]} bundle exec rake #{flavor}:index"
+            user node[:owner_name]
+          end
         end
       end
     end


### PR DESCRIPTION
Sphinx recipe blows up if run before the app is deployed, which leaves the environment in a red state which prevents deploy!  This is the solution we've been using for the past couple years at MUBI.
