### PR TITLE
Add `redis_instance` entry to /etc/hosts for easy access

### DIFF
--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -14,6 +14,7 @@ Design
 * 1+ utility instances
 * over-commit is enabled by default to ensure the least amount of problems saving your database.
 * 64-bit is required for storing over 2gigabytes worth of keys.
+* /etc/hosts mapping for `redis_instance` so that a hard config can be used to connect
 
 Backups
 --------

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -66,3 +66,26 @@ if ['util'].include?(node[:instance_role])
     end
   end
 end
+
+if ['solo', 'app', 'app_master', 'util'].include?(node[:instance_role])
+  redis_instance = if node.engineyard.environment.solo_cluster?
+    node.engineyard.environment.instances.first
+  else
+    node.engineyard.environment.utility_instances.find {|x| x.name == "redis"}
+  end
+
+  if redis_instance
+    redis_instance_ip_address = `ping -c 1 #{redis_instance.private_hostname} | awk 'NR==1{gsub(/\\(|\\)/,"",$3); print $3}'`.chomp
+    redis_instance_host_mapping = "#{redis_instance_ip_address} redis_instance"
+
+    execute "Remove existing redis_instance mapping from /etc/hosts" do
+      command "sudo sed -i '/redis_instance/d' /etc/hosts"
+      action :run
+    end
+
+    execute "Add redis_instance mapping to /etc/hosts" do
+      command "sudo echo #{redis_instance_host_mapping} >> /etc/hosts"
+      action :run
+    end
+  end
+end


### PR DESCRIPTION
By adding redis_instance to the /etc/hosts file, application configuration can access the alias rather than needing to alter configs of every process that needs access to redis.  This change is designed to work for solo, cluster, app instance access, util instance access (eg. resque in our case) and is guarded for environments that do not even have a redis instance.

I also cleaned up some outdated references in the docs.
