### PR TITLE
Current node shouldn't be excluded from expected_nodes in elasticsearch cookbook

### DIFF
--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -13,7 +13,7 @@ if ['util'].include?(node[:instance_role])
     node['utility_instances'].each do |elasticsearch|
       if elasticsearch['name'].include?("elasticsearch_")
         elasticsearch_expected = elasticsearch_expected + 1
-        elasticsearch_instances << "#{elasticsearch['hostname']}:9300" unless node['fqdn'] == elasticsearch['hostname']
+        elasticsearch_instances << "#{elasticsearch['hostname']}:9300"
       end
     end
   end


### PR DESCRIPTION
This could trigger early gateway recovery before it's wanted.
