### PR TITLE
Add elasticsearch jar from current version to classpath in shell script.

### DIFF
--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -115,7 +115,8 @@ if ['util'].include?(node[:instance_role])
     mode 0644
     backup 0
     variables(
-      :es_max_mem => ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m"
+      :es_max_mem => ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m",
+      :es_version => node[:elasticsearch_version]
     )
   end
 

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
@@ -1,4 +1,4 @@
-ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/elasticsearch-0.16.3.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
+ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/elasticsearch-<%= @es_version %>.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
 
 if [ "x$ES_MIN_MEM" = "x" ]; then
     ES_MIN_MEM=256m


### PR DESCRIPTION
If engineyard/ey-cloud-recipes#38 is resolved with more version flexibility (and if even if it isn't), elasticsearch.in.sh.erb should add the elasticsearch jar of the current elasticsearch version to the classpath before the other contents of the lib directory. This isn't necessary in 0.19, but is necessary for older versions as well as elasticsearch 0.20+ due to elasticsearch/elasticsearch@2b893fe1e54ee35bdddc1881d96fc831e617d630 fixing elasticsearch/elasticsearch#2058.
