### PR TITLE
Updated shared_db to account for multi-app environment

### DIFF
--- a/cookbooks/shared_db/recipes/default.rb
+++ b/cookbooks/shared_db/recipes/default.rb
@@ -6,17 +6,18 @@
 # by Adam Holt (@omgitsads)
 #
 
-# Name of the application
-app = "myapp"
-app_path = "/data/#{app}/shared/config/database.yml"
+# Array of applications that you wish to write the shared database configuration to
+apps = ["myapp"]
 
 # The name of the application with db credentials you want to use
 parent_app = "parentapp"
 parent_app_path = "/data/#{parent_app}/shared/config/database.yml"
 
-if app && parent_app
-  execute "Symlink #{parent_app_path} to #{app_path}" do
-    command "ln -sf #{parent_app_path} #{app_path}"
-    only_if "test -f #{parent_app_path}"
-  end
+if apps && parent_app
+  for app in apps
+		execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
+			command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
+			only_if "test -f #{parent_app_path}"
+		end
+	end
 end


### PR DESCRIPTION
This update makes things easier for people with more than two apps in an environment able to share a single database. Also discourages the use of keep files and deploy hooks in applications so big win there :wink: