### PR TITLE
added cookbook to automate package installation via cookbook attributes

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -42,6 +42,10 @@
 #  password "password"
 #end
 
+#uncomment to install specified packages
+# You must add your packages to packages/attributes/packages.rb
+#require_recipe "packages"
+
 #uncomment to run the exim::auth recipe
 #include_recipe "exim::auth"
 #include_recipe "mongodb"

--- a/cookbooks/packages/README.md
+++ b/cookbooks/packages/README.md
@@ -1,0 +1,14 @@
+Packages Cookbook for Engine Yard Cloud
+=======================================
+
+This cookbook allows you to automate the installation of packages using the attributes in this cookbook.  All packages are unmasked before installing.  Edit attributes/packages.rb and require this cookbook in the main cookbook recipe. 
+
+Example
+--------
+
+```
+packages( 
+    [{:name => "app-misc/wkhtmltopdf-bin", :version => "0.10.0_beta5"},
+     {:name => "dev-util/lockrun", :version => "2-r1"}]
+)
+```

--- a/cookbooks/packages/attributes/packages.rb
+++ b/cookbooks/packages/attributes/packages.rb
@@ -1,0 +1,13 @@
+# Specify packages and version numbers to be installed here
+#
+# Search for packages on instances using: eix <package name> 
+# Or go to the dashboard and edit the packages for an application to view *unmasked* packages
+# Note that the dashboard view will not list unmasked packages
+#
+# Examples below:
+
+packages( 
+    [{:name => "app-misc/wkhtmltopdf-bin", :version => "0.10.0_beta5"},
+     {:name => "dev-util/lockrun", :version => "2-r1"}]
+)
+    

--- a/cookbooks/packages/recipes/default.rb
+++ b/cookbooks/packages/recipes/default.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: packages
+# Recipe:: default
+#
+
+node[:packages].each do |package|
+
+  ey_cloud_report "package-install" do
+    message "Installing #{package[:name]}-#{package[:version]}"
+  end
+  
+  enable_package package[:name] do
+    version package[:version]
+  end
+    
+  package package[:name] do 
+    version package[:version]
+    action :install 
+  end
+
+end
+


### PR DESCRIPTION
## Description of your patch

Adds a cookbook to automate package installation.  Package names and versions are specified as hashes in the attributes file.
## Estimated risk

zero, the require_package is commented out in the main recipe
## Components involved

emerge cookbook
## Description of testing done

tested with examples in cookbook on personal instance
## QA Instructions

uncomment require_recipe "packages" in main recipe, upload and apply to instance
