### PR TITLE
[CC-326] Sidekiq Recipe

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -13,6 +13,9 @@
 # uncomment to use the block recipe. See cookbooks/block/readme.md for documentation.
 # require_recipe "ban"
 
+# uncomment to use the sidekiq recipe. See cookbooks/sidekiq/readme.md for documentation.
+# require_recipe "sidekiq"
+
 #uncomment to turn on memcached
 # require_recipe "memcached"
 

--- a/cookbooks/sidekiq/attributes/default.rb
+++ b/cookbooks/sidekiq/attributes/default.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: sidekiq
+# Attrbutes:: default
+#
+
+sidekiq({
+  # Sidekiq will be installed on to application/solo instances,
+  # unless a utility name is set, in which case, Sidekiq will
+  # only be installed on to a utility instance that matches
+  # the name
+  :utility_name => 'sidekiq',
+  
+  # Number of workers (not threads)
+  :workers => 1,
+  
+  # Concurrency
+  :concurrency => 25,
+  
+  # Queues
+  :queues => {
+    # :queue_name => priority
+    :default => 1
+  },
+  
+  # Verbose
+  :verbose => false
+})

--- a/cookbooks/sidekiq/files/default/sidekiq
+++ b/cookbooks/sidekiq/files/default/sidekiq
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+#   /engineyard/bin/sidekiq
+#
+#   Author: Jim Neath (jneath@engineyard.com)
+#
+
+# must be root
+if [[ "$(whoami)" != "root" ]]; then
+  echo "Must be run as root"
+  exit 1
+fi
+
+# arguments 
+[[ $# -ne 4 ]] && usage
+app_name=$1 action=$2 rails_env=$3 worker_id=$4
+
+# variables
+app_root="/data/${app_name}/current"
+worker_ref="sidekiq_${worker_id}"
+pid_dir="/var/run/engineyard/sidekiq/${app_name}"
+pid_file="${pid_dir}/${worker_ref}.pid"
+log_file="${app_root}/log/${worker_ref}.log"
+conf_file="/data/${app_name}/shared/config/${worker_ref}.yml"
+
+# add binstubs to $PATH
+export PATH="${app_root}/ey_bundler_binstubs:$PATH"
+
+# script usage
+usage ()
+{
+  echo "Usage: $0 <app_name> {start|stop} <rails_env> <worker_id>"
+  exit 1
+}
+
+# start sidekiq
+start ()
+{
+  # check if process is already running
+  if [[ -f $pid_file ]]; then
+    pid=$(cat "${pid_file}")
+    
+    if [[ -d /proc/$pid ]]; then
+      echo "${0} is already running (${pid})"
+      exit 1
+    else
+      rm -f "${pid_file}"
+    fi
+  fi
+  
+  # start sidekiq
+  sidekiq -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" &
+  exit $?
+}
+
+# stop sidekiq
+stop ()
+{
+  # stop using sidekiqctl
+  sidekiqctl stop "${pid_file}"
+  exit $?
+}
+
+# sanity checks
+[[ ! -L $app_root ]] && { echo "${app_root} does not exist"; exit 1; }
+[[ ! -f $conf_file ]] && { echo "${conf_file} does not exist"; exit 1; }
+[[ ! -d $pid_dir ]] && mkdir -p "${pid_dir}" 
+
+# execute action
+case "${action}" in
+  start) start;;
+  stop) stop;;
+  *) usage;;
+esac

--- a/cookbooks/sidekiq/libraries/instance_roles.rb
+++ b/cookbooks/sidekiq/libraries/instance_roles.rb
@@ -1,0 +1,55 @@
+class Chef
+  class Recipe
+    def solo?
+      instance_role?(:solo)
+    end
+
+    def app_master?
+      instance_role?(:app_master, :solo)
+    end
+
+    def app_server?
+      instance_role?(:app_master, :app, :solo)
+    end
+    
+    def db_master?
+      instance_role?(:db_master, :solo)
+    end
+    
+    def db_slave?
+      instance_role?(:db_slave)
+    end
+    
+    def db_server?
+      instance_role?(:db_master, :db_slave, :solo)
+    end
+    
+    def util?(name = nil)
+      instance_role?(:util) && instance_named?(name)
+    end
+    
+    def has_util?(name = nil)
+      node[:utility_instances].any? do |util|
+        name.empty? || util[:name][/#{name}/i]
+      end
+    end
+    
+    def util_or_app_server?(name = nil)
+      if name.to_s != "" && has_util?(name)
+        util?(name)
+      else
+        app_server?
+      end
+    end
+    
+    protected
+    
+    def instance_role?(*roles)
+      [*roles].flatten.map{|r| r.to_s}.include?(node[:instance_role])
+    end
+    
+    def instance_named?(str = nil)
+      str.to_s == "" || node[:name][/#{str}/i]
+    end
+  end
+end

--- a/cookbooks/sidekiq/readme.md
+++ b/cookbooks/sidekiq/readme.md
@@ -1,0 +1,72 @@
+# Sidekiq
+
+## Introduction
+
+Sidekiq is a simple, efficient message processing for Ruby that uses threads to handle many messages at the same time in the same process. It does not require Rails but will integrate tightly with Rails 3 to make background message processing dead simple.
+
+https://github.com/mperham/sidekiq
+
+## Usage
+
+First ensure that you have Sidekiq working in your development environment by following the Sidekiq "Getting Started" guide:
+
+https://github.com/mperham/sidekiq/wiki/Getting-Started
+
+To install Sidekiq to your environment, first uncomment the following line in `main/recipes/default.rb`:
+
+```
+require_recipe "sidekiq"
+```
+
+Next, update the settings in `sidekiq/attributes/default.rb`:
+
+```
+sidekiq({
+  # Sidekiq will be installed on to application/solo instances,
+  # unless a utility name is set, in which case, Sidekiq will
+  # only be installed on to a utility instance that matches
+  # the name
+  :utility_name => 'sidekiq',
+  
+  # Number of workers (not threads)
+  :workers => 1,
+  
+  # Concurrency
+  :concurrency => 25,
+  
+  # Queues
+  :queues => {
+    # :queue_name => priority
+    :default => 1
+  },
+  
+  # Verbose
+  :verbose => false
+})
+```
+
+By default, the recipe will install Sidekiq on to a utility instance with the name `sidekiq`. If the utility name is `nil` or there is no utility instance matching the name given, Sidekiq will be installed on all application/solo instances.
+
+If you wish to have more than one sidekiq utility instance, you can name them `sidekiq_1`, `sidekiq_2`, etc, given the `utility_name` is set to `sidekiq`.
+
+## Deploy Hooks
+
+You will need to add a deploy hook to restart Sidekiq during deploys. Add the following to `deploy/after_restart.rb`:
+
+```
+on_utilities("sidekiq") do
+  sudo "monit restart all -g sidekiq_<app_name>"
+end
+```
+
+If Sidekiq is installed on your application instances, rather than a utility instance, you can do the following:
+
+```
+on_app_servers do
+  sudo "monit restart all -g sidekiq_<app_name>"
+end
+```
+
+More information regarding deploy hooks can be found here:
+
+https://engineyard.zendesk.com/entries/21016568-use-deploy-hooks

--- a/cookbooks/sidekiq/recipes/cleanup.rb
+++ b/cookbooks/sidekiq/recipes/cleanup.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: sidekiq
+# Recipe:: cleanup
+#
+
+# reload monit
+execute "reload-monit" do
+  command "monit quit && telinit q"
+  action :nothing
+end
+
+unless util_or_app_server?(node[:sidekiq][:utility_name]) 
+  # report to dashboard
+  ey_cloud_report "sidekiq" do
+    message "Cleaning up sidekiq (if needed)"
+  end
+  
+  if app_server? || util?
+    # loop through applications
+    node[:applications].each do |app_name, _|
+      # monit
+      file "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
+        action :delete
+        notifies :reload, resources(:execute => "reload-monit")
+      end
+
+      # yml files
+      node[:sidekiq][:workers].times do |count|
+        file "/data/#{app_name}/shared/config/sidekiq_#{count}.yml" do
+          action :delete
+        end
+      end
+    end 
+
+    # bin script
+    file "/engineyard/bin/sidekiq" do
+      action :delete
+    end
+
+    # stop sidekiq
+    execute "kill-sidekiq" do
+      command "pkill -f sidekiq"
+      only_if "pgrep -f sidekiq"
+    end
+  end
+end

--- a/cookbooks/sidekiq/recipes/default.rb
+++ b/cookbooks/sidekiq/recipes/default.rb
@@ -1,0 +1,7 @@
+#
+# Cookbook Name:: sidekiq
+# Recipe:: default
+#
+
+include_recipe "sidekiq::cleanup"
+include_recipe "sidekiq::setup"

--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -1,0 +1,54 @@
+#
+# Cookbook Name:: sidekiq
+# Recipe:: setup
+#
+
+if util_or_app_server?(node[:sidekiq][:utility_name]) 
+  # report to dashboard
+  ey_cloud_report "sidekiq" do
+    message "Setting up sidekiq"
+  end
+
+  # bin script
+  remote_file "/engineyard/bin/sidekiq" do
+    mode 0755
+    source "sidekiq" 
+    backup false
+  end
+  
+  # loop through applications
+  node[:applications].each do |app_name, _|
+    # reload monit
+    execute "restart-sidekiq-for-#{app_name}" do
+      command "monit reload && sleep 1 && monit restart all -g #{app_name}_sidekiq"
+      action :nothing
+    end
+    
+    # monit
+    template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
+      mode 0644 
+      source "sidekiq.monitrc.erb" 
+      backup false
+      variables({ 
+        :app_name => app_name, 
+        :workers => node[:sidekiq][:workers],
+        :rails_env => node[:environment][:framework_env],
+        :memory_limit => 400 # MB
+      })
+      notifies :run, resources(:execute => "restart-sidekiq-for-#{app_name}")
+    end
+
+    # yml files
+    node[:sidekiq][:workers].times do |count|
+      template "/data/#{app_name}/shared/config/sidekiq_#{count}.yml" do
+        owner node[:owner_name]
+        group node[:owner_name]
+        mode 0644
+        source "sidekiq.yml.erb"
+        backup false
+        variables(node[:sidekiq])
+        notifies :run, resources(:execute => "restart-sidekiq-for-#{app_name}")
+      end
+    end
+  end 
+end

--- a/cookbooks/sidekiq/templates/default/sidekiq.monitrc.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.monitrc.erb
@@ -1,0 +1,9 @@
+<% @workers.times do |count| %>
+# sidekiq worker <%= count %>
+check process sidekiq_<%= @app_name %>_<%= count %>
+  with pidfile /var/run/engineyard/sidekiq/<%= @app_name %>/sidekiq_<%= count %>.pid
+  start program = "/engineyard/bin/sidekiq <%= @app_name %> start <%= @rails_env %> <%= count %>" with timeout 90 seconds
+  stop program = "/engineyard/bin/sidekiq <%= @app_name %> stop <%= @rails_env %> <%= count %>" with timeout 90 seconds
+  if totalmem is greater than <%= @memory_limit %> MB for 3 cycles then restart 
+  group <%= @app_name %>_sidekiq
+<% end %>

--- a/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
@@ -1,0 +1,9 @@
+# sidekiq settings
+# see: https://github.com/mperham/sidekiq/blob/master/examples/config.yml
+---
+:verbose: <%= @verbose %>
+:concurrency: <%= @concurrency %>
+:queues:
+<% @queues.to_a.each do |q| %>
+  - [<%= q.join(', ') %>]
+<% end %>


### PR DESCRIPTION
## Description of your patch

Installs sidekiq on to a utility slice named "sidekiq" or "sidekiq_1", etc if present, otherwise falls back to installing on app instances/solo instance.
## Description of testing done

You can use the sidekiq branch of my slater app: https://github.com/jimneath/slater/tree/sidekiq
- Boot a solo environment
- Run recipe
- Sidekiq process should be running on the solo instance
- Boot util named sidekiq
- Sidekiq should now be present on the util and removed from the solo
- Boot additional util with random name
- Sidekiq should not be present on the new util
- Shutdown the "sidekiq" util
- Run recipes
- Sidekiq should now be on the solo again
## QA Instructions

As above
