### PR TITLE
[CC-397] Use include_recipe over the deprecated require_recipe

### DIFF
--- a/cookbooks/api-keys-yml/README.md
+++ b/cookbooks/api-keys-yml/README.md
@@ -7,7 +7,7 @@ This Chef recipe will write api-keys.yml to your Rails app's config/ directory o
 
 1. Populate the templates/default/api-keys.yml.erb with your production-ready API keys.
 2. Have your Rails app check locally at `config/api-keys.yml` for all API keys that it needs.
-3. Be sure to uncomment `require_recipe "api-keys-yml"` from `cookbooks/main/default/recipes.rb` per usual.
+3. Be sure to uncomment `include_recipe "api-keys-yml"` from `cookbooks/main/default/recipes.rb` per usual.
 4. That's it! Upload (`ey recipes upload -e [env]`) and apply (`ey recipes apply -e [env]`)
 
 Optional: 

--- a/cookbooks/delayed_job/README.markdown
+++ b/cookbooks/delayed_job/README.markdown
@@ -10,7 +10,7 @@ vary based on the size of the instance running Delayed Job.
 
 To install this, you will need to add the following to cookbooks/main/recipes/default.rb:
 
-    require_recipe "delayed_job"
+    include_recipe "delayed_job"
     
 Make sure this and any customizations to the recipe are committed to your own fork of this 
 repository.

--- a/cookbooks/elasticsearch/README.md
+++ b/cookbooks/elasticsearch/README.md
@@ -19,11 +19,11 @@ Using it
 
   * There is two ways to run this recipe.  By default you can use the 'default' recipe and use this in an clustered configuration that requires utility instances.  Alternatively you can use the alternate recipe called 'non_util' which will configure your app_master/solo instance to have elasticsearch.  You would add to main/recipes/default.rb the following,
 
-``require_recipe "elasticsearch::non_util"``  
+``include_recipe "elasticsearch::non_util"``  
 
   * Otheriwse you would do the following
 
-``require_recipe "elasticsearch"``  
+``include_recipe "elasticsearch"``  
 
   * Now you should upload the recipes to your environment,
   

--- a/cookbooks/eybackup_verbose/README.rdoc
+++ b/cookbooks/eybackup_verbose/README.rdoc
@@ -8,7 +8,7 @@ This Cookbook should be relatively safe and harmless; however if you move eyback
 
 = USAGE: 
 
-Uncomment require_recipe "eybackup_verbose" in main/recipes/default.rb
+Uncomment include_recipe "eybackup_verbose" in main/recipes/default.rb
 
 = CREDITS:
 

--- a/cookbooks/logrotate/README.rdoc
+++ b/cookbooks/logrotate/README.rdoc
@@ -6,7 +6,7 @@ Logrotate cookbook, primarily this cookbook is only setup currently to rotate ng
 
 uncomment / add to main/recipes/default.rb
 
-require_recipe "logrotate"
+include_recipe "logrotate"
 
 = NOTES:
 

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -5,34 +5,34 @@
 #end
 
 # uncomment to turn on thinking sphinx/ultra sphinx. Remember to edit cookbooks/sphinx/recipes/default.rb first!
-# require_recipe "sphinx"
+# include_recipe "sphinx"
 
 # uncomment to use the collectd recipe. See cookbooks/collectd/readme.md for documentation.
-# require_recipe "collectd"
+# include_recipe "collectd"
 
 # uncomment to use the block recipe. See cookbooks/block/readme.md for documentation.
-# require_recipe "ban"
+# include_recipe "ban"
 
 # uncomment to use the sidekiq recipe. See cookbooks/sidekiq/readme.md for documentation.
-# require_recipe "sidekiq"
+# include_recipe "sidekiq"
 
 #uncomment to turn on memcached
-# require_recipe "memcached"
+# include_recipe "memcached"
 
 #uncomment ot run the riak recipe
-# require_recipe "riak"
+# include_recipe "riak"
 
 #uncomment to run the authorized_keys recipe
-#require_recipe "authorized_keys"
+#include_recipe "authorized_keys"
 
 #uncomment to run the eybackup_slave recipe
-#require_recipe "eybackup_slave"
+#include_recipe "eybackup_slave"
 
 #uncomment to run the ssmtp recipe
-#require_recipe "ssmtp"
+#include_recipe "ssmtp"
 
 #uncomment to run the sunspot recipe
-# require_recipe "sunspot"
+# include_recipe "sunspot"
 
 #uncomment to run the exim recipe
 #exim_auth "auth" do
@@ -43,42 +43,42 @@
 #end
 
 #uncomment to run the exim::auth recipe
-#require_recipe "exim::auth"
-#require_recipe "mongodb"
+#include_recipe "exim::auth"
+#include_recipe "mongodb"
 
 #uncomment to run the resque recipe
-# require_recipe "resque"
+# include_recipe "resque"
 
 #uncomment to run redis.yml recipe
-# require_recipe "redis-yml"
+# include_recipe "redis-yml"
 
 #uncomment to run the resque-scheduler recipe
-# require_recipe "resque-scheduler"
+# include_recipe "resque-scheduler"
 
 #uncomment to run the redis recipe
-#require_recipe "redis"
+#include_recipe "redis"
 
 #uncomment to run the api-keys-yml recipe
-# require_recipe "api-keys-yml"
+# include_recipe "api-keys-yml"
 
-#require_recipe "logrotate"
+#include_recipe "logrotate"
 #
 #uncomment to use the solr recipe
-#require_recipe "solr"
+#include_recipe "solr"
 
-#require_recipe "varnish_frontend"
+#include_recipe "varnish_frontend"
 #uncomment to include the eybackup_verbose recipe
-#require_recipe "eybackup_verbose"
+#include_recipe "eybackup_verbose"
 
 #uncomment to include the mysql_replication_check recipe
-#require_recipe "mysql_replication_check"
+#include_recipe "mysql_replication_check"
 
 #uncomment to include the mysql_administrative_tools recipe
 # additional configuration of this recipe is required
-#require_recipe "mysql_administrative_tools"
+#include_recipe "mysql_administrative_tools"
 
 #uncomment to include the Elasticsearch recipe
-#require_recipe "elasticsearch"
+#include_recipe "elasticsearch"
 
 # To install specific plugins to Elasticsearch see below as an example
 #es_plugin "cloud-aws" do

--- a/cookbooks/mongodb/README.md
+++ b/cookbooks/mongodb/README.md
@@ -19,7 +19,7 @@ Using it
 
   * add the following to main/recipes/default.rb,
 
-``require_recipe "mongodb"``
+``include_recipe "mongodb"``
 
   * Upload recipes to your environment
 

--- a/cookbooks/mongodb/recipes/default.rb
+++ b/cookbooks/mongodb/recipes/default.rb
@@ -5,7 +5,7 @@
 # Save credentials on app_master
 if ['app_master','app','solo','util'].include? @node[:instance_role]
   Chef::Log.info "creating app mongo.yml code"
-  require_recipe "mongodb::app"
+  include_recipe "mongodb::app"
 end
 
 case node[:kernel][:machine]
@@ -19,28 +19,28 @@ else
       message "configuring mongodb"
     end
 
-    require_recipe "mongodb::install"
-    require_recipe "mongodb::configure"
-    require_recipe "mongodb::backup"
-    require_recipe "mongodb::start"
+    include_recipe "mongodb::install"
+    include_recipe "mongodb::configure"
+    include_recipe "mongodb::backup"
+    include_recipe "mongodb::start"
 
     if @node[:mongo_replset]
-      require_recipe "mongodb::replset"
+      include_recipe "mongodb::replset"
     end
   end
 
   # Setup an arbiter on the db_master|solo as replica sets need another vote to properly failover.  If you have a Replica set > 3 nodes we don't set this up, you can tune this obviously.
   if (['db_master','solo'].include?(@node[:instance_role]) &&  @node[:mongo_utility_instances].length == 2)
     Chef::Log.info "Setting up Mongo in db_master or solo"
-    require_recipe "mongodb::install"
-    require_recipe "mongodb::configure"
-    require_recipe "mongodb::backup"
-    require_recipe "mongodb::start"
+    include_recipe "mongodb::install"
+    include_recipe "mongodb::configure"
+    include_recipe "mongodb::backup"
+    include_recipe "mongodb::start"
   end
 end
 
 #install mms on db_master or solo. This will need to change for db-less environments
 if ['db_master', 'solo'].include? @node[:instance_role]
   Chef::Log.info "Installing MMS on #{@node[:instance_role]}"
-  require_recipe "mongodb::install_mms"
+  include_recipe "mongodb::install_mms"
 end

--- a/cookbooks/rds/README.md
+++ b/cookbooks/rds/README.md
@@ -15,6 +15,6 @@ Enabling this recipe
 ---------------------------
 
 * Edit main/recipes/default.rb and comment out the line shown below.
-``require_recipe "rds"``
+``include_recipe "rds"``
 * Alter the rds/attributes/rds.rb file to include your connection
   information.

--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -37,7 +37,7 @@ Installation
 Ensure you have the Dependencies installed in your local cookbooks repository ...
 Add the following to your main/recipes/default.rb
 
-``require_recipe "redis"``
+``include_recipe "redis"``
 
 How to get Support
 --------

--- a/cookbooks/resque/README.rdoc
+++ b/cookbooks/resque/README.rdoc
@@ -4,7 +4,7 @@ Resque is a Redis-backed Ruby library for creating background jobs, placing thos
 
 = USAGE: 
 
-add require_recipe "resque" to main/recipes/default.rb
+add include_recipe "resque" to main/recipes/default.rb
 
 = NOTES:
 

--- a/cookbooks/shared_db/README.md
+++ b/cookbooks/shared_db/README.md
@@ -8,4 +8,4 @@ multiple-application environment.
 Modify the `app` and `parent_app` variables in the default recipe then require
 it in the `cookbooks/main/recipes/default.rb`.
 
-    require_recipe "shared_db"
+    include_recipe "shared_db"

--- a/cookbooks/sidekiq/readme.md
+++ b/cookbooks/sidekiq/readme.md
@@ -15,7 +15,7 @@ https://github.com/mperham/sidekiq/wiki/Getting-Started
 To install Sidekiq to your environment, first uncomment the following line in `main/recipes/default.rb`:
 
 ```
-require_recipe "sidekiq"
+include_recipe "sidekiq"
 ```
 
 Next, update the settings in `sidekiq/attributes/default.rb`:

--- a/cookbooks/solr/README.rdoc
+++ b/cookbooks/solr/README.rdoc
@@ -7,7 +7,7 @@ This Cookbook is for an "Unsupported" Stack item; Engine Yard does not support m
 
 = USAGE:
 
-require_recipe "solr" in main/recipes/default.rb
+include_recipe "solr" in main/recipes/default.rb
 
 = RAMBLINGS:
 

--- a/cookbooks/ssh_tunnel/recipes/default.rb
+++ b/cookbooks/ssh_tunnel/recipes/default.rb
@@ -6,7 +6,7 @@
 # if you want to have more than one tunnel set up on a given instance
 # (which should be fairly rare) then copy the entire cookbook with a
 # different top level name (don't change any filenames in it) and change 
-# this value to match before deploying.  Oh, and be sure to add a require_recipe 
+# this value to match before deploying.  Oh, and be sure to add a include_recipe 
 # line with the new cookbook name to the main cookbook's default.rb recipe file
 tunnel_name = 'ssh_tunnel'
 

--- a/cookbooks/ssmtp/README.rdoc
+++ b/cookbooks/ssmtp/README.rdoc
@@ -2,7 +2,7 @@
 
 This recipe deletes the content of /etc/ssmtp and symlinks /etc/ssmtp to /data/ssmtp so that mail server configs are preserved when instances are terminated.
 
-1. Ensure ssmtp recipes in cookbooks/main/recipes/default.rb are not commented out: require_recipe "ssmtp"
+1. Ensure ssmtp recipes in cookbooks/main/recipes/default.rb are not commented out: include_recipe "ssmtp"
 2. Upload the recipe to the correct environment:
   ey recipes upload -e production
   ey recipes apply -e production

--- a/cookbooks/timezone/README.md
+++ b/cookbooks/timezone/README.md
@@ -11,7 +11,7 @@ Take a look in `/usr/share/zoneinfo` to find the relevant timezone, and set the 
 
 Add the following to cookbooks/main/recipes/default.rb:
 
-    require_recipe "timezone"
+    include_recipe "timezone"
 
 
 NOTE: the recipe has 'UTC' as an example timezone, so make sure you change as necessary before using.


### PR DESCRIPTION
`require_recipe` is deprecated and the method in chef 0.6, just calls `include_recipe` anyway, so I've updated the recipes to use `include_recipe`.
