### PR TITLE
Remove ruby flag from gdal compilation

### DIFF
--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
@@ -9,12 +9,14 @@ if @node[:postgres_version] == "9.2"
   end
 
   enable_package "sci-libs/gdal" do
+    flags "-ruby"
     version gdal_version
   end
 
   enable_package "sci-libs/geos" do
     version geos_version
   end
+
   enable_package "sci-libs/proj" do
     version proj_version
   end


### PR DESCRIPTION
With ruby compilation flag installation of gdal on an r4 stack fails with compilation exception about missing 'ruby.h'.

So I suggest removing this flag.
