### PR TITLE
Fix bug when outputting env vars

### DIFF
--- a/cookbooks/env_vars/README.md
+++ b/cookbooks/env_vars/README.md
@@ -4,15 +4,15 @@ Environment Variables for Cloud
 This cookbook allows you to set environment variables for any application server that sources /data/INSERT_APP_NAME/shared/env.custom, this includes Unicorn and PHP-FPM.  If Passenger is used, a Ruby wrapper script is created and the passenger_ruby directive is added in the Nginx configuration.  This script just sources the env.custom file and calls Ruby.
 
 Set environment variables in attributes/env_vars.rb
-  
+
   Example:
-  
+
   ```
-  env_vars( 
-      [{:RUBY_HEAP_MIN_SLOTS => "10000"},
-       {:RUBY_HEAP_SLOTS_INCREMENT => "10000"},
-       {:RUBY_HEAP_SLOTS_GROWTH_FACTOR => "1.8"},
-       {:RUBY_GC_MALLOC_LIMIT => "8000000"},
-       {:RUBY_HEAP_FREE_MIN => "4096"}]
-  )
+  default[:env_vars] = {
+    :RUBY_HEAP_MIN_SLOT => "10000",
+    :RUBY_HEAP_SLOTS_INCREMENT => "10000",
+    :RUBY_HEAP_SLOTS_GROWTH_FACTOR => "1.8",
+    :RUBY_GC_MALLOC_LIMIT => "8000000",
+    :RUBY_HEAP_FREE_MIN => "4096",
+  }
   ```

--- a/cookbooks/env_vars/templates/default/env.custom.erb
+++ b/cookbooks/env_vars/templates/default/env.custom.erb
@@ -1,3 +1,3 @@
-<% @env_vars.each do |env_var| %>
-<% env_var.each do |key, value| %>export <%= key.upcase %>=<%= value %><% end %>
+<% @env_vars.each do |key, value| %>
+export <%= key.upcase %>=<%= value %>
 <% end %>


### PR DESCRIPTION
templates/default/env.custom.erb had been broken when you changed env_vars in env_vars.rb.

You now just have a hash, not hashes in an array.
