### PR TITLE
[CC-400] New sphinx recipe (adds Thinking Sphinx 3 support, drops Thinking Sphinx 2 and UltraSphinx support)

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -4,8 +4,11 @@
 #  }
 #end
 
-# uncomment to turn on thinking sphinx/ultra sphinx. Remember to edit cookbooks/sphinx/recipes/default.rb first!
+# uncomment to turn on thinking sphinx 2/ultra sphinx. Remember to edit cookbooks/sphinx/recipes/default.rb first!
 # include_recipe "sphinx"
+
+# uncomment to turn on thinking sphinx 3. See cookbooks/thinking-sphinx-3/readme.md for documentation.
+# include_recipe "thinking-sphinx-3"
 
 # uncomment to use the collectd recipe. See cookbooks/collectd/readme.md for documentation.
 # include_recipe "collectd"

--- a/cookbooks/sphinx/README.md
+++ b/cookbooks/sphinx/README.md
@@ -1,7 +1,7 @@
 ey-cloud-recipes/sphinx
 ========================
 
-This recipe is for configuring and deploying sphinx on AppCloud. This is for Rails 3.
+This recipe is for configuring and deploying sphinx on AppCloud. This is for Rails 3. For Thinking Sphinx 3 support, please use the [Thinking Sphinx 3 cookbook](https://github.com/engineyard/ey-cloud-recipes/tree/master/cookbooks/thinking-sphinx-3)
 
 Dependencies
 ============

--- a/cookbooks/thinking-sphinx-3/README.md
+++ b/cookbooks/thinking-sphinx-3/README.md
@@ -1,0 +1,33 @@
+# Sphinx
+
+This cookbook will install [Sphinx](http://sphinxsearch.com/) and setup an environment to use Thinking Sphinx 3. For Thinking Sphinx 2 or UltraSphinx support, please use the [Sphinx cookbook](https://github.com/engineyard/ey-cloud-recipes/tree/master/cookbooks/sphinx)
+
+## Setup
+
+This cookbook will install Sphinx on a  utility instance that matches the name set in `attributes/default.rb`. If no utility instance can be found with that name, Sphinx will be setup on every application instance (this includes the application master or solo instances).
+
+By default, the cookbook will look for a utility instance named `sphinx` and will install Sphinx 2.0.6 to run for all applications in the environment. It will also setup a cronjob to reindex every 15 minutes. These settings can be modified in the `attributes/default.rb` file.
+
+# Usage
+
+Uncomment the following line inside of `main/recipes/default.rb`:
+
+```
+include_recipe "sphinx"
+```
+
+Then upload and apply your cookbooks:
+
+```
+ey recipes upload
+ey recipes apply
+```
+
+You will also need to add a deploy hook to restart Sphinx on deploy. Create a file called `deploy/after_symlink.rb` inside of of you application with the following contents:
+
+```
+on_app_servers_and_utilities do
+  run "[[ -d #{shared_path}/sphinx ]] && ln -nfs #{shared_path}/sphinx #{current_path}/db/sphinx"
+  run "cd #{current_path} && RAILS_ENV=#{environment} bundle exec rake ts:configure"
+end
+```

--- a/cookbooks/thinking-sphinx-3/attributes/default.rb
+++ b/cookbooks/thinking-sphinx-3/attributes/default.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: sphinx
+# Attrbutes:: default
+#
+
+default[:sphinx] = {
+  # Sphinx will be installed on to application/solo instances,
+  # unless a utility name is set, in which case, Sphinx will
+  # only be installed on to a utility instance that matches
+  # the name
+  :utility_name => 'sphinx',
+  
+  # The version of sphinx to install
+  :version => '2.0.6',
+  
+  # Applications that are using sphinx. Leave this blank to
+  # setup sphinx for each app in an environment
+  # :apps => ['todo', 'admin'],
+  :apps => [],
+  
+  # Index frequency. How often the indexer cron job should
+  # be run. A value of 15 will reindex every 15 minutes
+  :frequency => 15
+}
+
+# Note: You do not need to edit below this line
+
+# Store sphinx node as attribute
+util = node[:engineyard][:environment][:instances].find{|i| i[:name].to_s == default[:sphinx][:utility_name]}
+Chef::Log.info "SPHINX INSTANCE: #{util.inspect}"
+
+default[:sphinx][:host] = util ? util[:private_hostname] : '127.0.0.1'
+Chef::Log.info "SPHINX HOST: #{default[:sphinx][:host]}"
+
+# Set apps key to all available apps if empty
+if default[:sphinx][:apps].empty?
+  default[:sphinx][:apps] = node[:engineyard][:environment][:apps].map{|a| a[:name]}
+end

--- a/cookbooks/thinking-sphinx-3/recipes/cleanup.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/cleanup.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook Name:: sphinx
+# Recipe:: cleanup
+#
+
+# reload monit
+execute "reload-monit" do
+  command "monit quit && telinit q"
+  action :nothing
+end
+
+unless util_or_app_server?(node[:sphinx][:utility_name]) 
+  # report to dashboard
+  ey_cloud_report "sphinx" do
+    message "Cleaning up sphinx (if needed)"
+  end
+  
+  if app_server? || util?
+    # loop through applications
+    node[:applications].each do |app_name, _|
+      # monit
+      file "/etc/monit.d/sphinx_#{app_name}.monitrc" do 
+        action :delete
+        notifies :run, resources(:execute => "reload-monit")
+        only_if "test -f /etc/monit.d/sphinx_#{app_name}.monitrc"
+      end
+    
+      # remove cronjob
+      cron "indexer-#{app_name}" do
+        action :delete
+      end
+    end 
+
+    # stop sphinx
+    execute "kill-sphinx" do
+      command "pkill -f searchd"
+      only_if "pgrep -f searchd"
+    end
+  end
+end

--- a/cookbooks/thinking-sphinx-3/recipes/default.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/default.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: sphinx
+# Recipe:: default
+#
+
+unless db_server?
+  include_recipe "sphinx::cleanup"
+  include_recipe "sphinx::install"
+  include_recipe "sphinx::thinking_sphinx"
+  include_recipe "sphinx::setup"
+end

--- a/cookbooks/thinking-sphinx-3/recipes/install.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/install.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: sphinx
+# Recipe:: install
+#
+
+# report to dashboard
+ey_cloud_report "sphinx" do
+  message "Installing sphinx"
+end
+
+# install package
+enable_package "app-misc/sphinx" do
+  version node[:sphinx][:version]
+end
+
+package "app-misc/sphinx" do
+  version node[:sphinx][:version]
+  action :install
+end

--- a/cookbooks/thinking-sphinx-3/recipes/setup.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/setup.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: sphinx
+# Recipe:: setup
+#
+
+if util_or_app_server?(node[:sphinx][:utility_name]) 
+  # report to dashboard
+  ey_cloud_report "sphinx" do
+    message "Setting up sphinx"
+  end
+  
+  node[:sphinx][:apps].each do |app_name|
+    # monit
+    execute "restart-sphinx-#{app_name}" do
+      command "monit reload && sleep 2s && monit restart sphinx_#{app_name}"
+      action :nothing
+    end
+    
+    # setup monit for each app defined (see attributes)
+    template "/etc/monit.d/sphinx_#{app_name}.monitrc" do
+      source "sphinx.monitrc.erb"
+      owner node[:owner_name]
+      group node[:owner_name]
+      mode "0644"
+      backup 0
+      variables({
+        :environment => node[:environment][:framework_env],
+        :user => node[:owner_name],
+        :pid_file => "/data/#{app_name}/shared/log/#{node[:environment][:framework_env]}.sphinx.pid",
+        :app_name => app_name
+      })
+      notifies :run, resources(:execute => "restart-sphinx-#{app_name}")
+    end
+
+    # indexer cron job
+    if node[:sphinx][:frequency].to_i > 0
+      cron "indexer-#{app_name}" do
+        command "/usr/bin/indexer -c /data/#{app_name}/current/config/#{node[:environment][:framework_env]}.sphinx.conf --all --rotate"
+        minute "*/#{node[:sphinx][:frequency]}"
+        user node[:owner_name]
+      end
+    end
+  end
+end

--- a/cookbooks/thinking-sphinx-3/recipes/thinking_sphinx.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/thinking_sphinx.rb
@@ -1,0 +1,71 @@
+#
+# Cookbook Name:: sphinx
+# Recipe:: thinking_sphinx
+#
+
+# setup thinking sphinx on each app (see attributes)
+node[:sphinx][:apps].each do |app_name|
+  # variables
+  current_path = "/data/#{app_name}/current"
+  shared_path = "/data/#{app_name}/shared"
+  env = node[:environment][:framework_env]
+  
+  # check that application is deployed
+  if File.symlink?(current_path)
+    # config yml
+    template "#{shared_path}/config/thinking_sphinx.yml" do
+      source "thinking_sphinx.yml.erb"
+      owner node[:owner_name]
+      group node[:owner_name]
+      mode "0644"
+      backup 0
+      variables({
+        :environment => env,
+        :address => node[:sphinx][:host],
+        :pid_file => "#{shared_path}/log/#{env}.sphinx.pid"
+      })
+    end
+      
+    if util_or_app_server?(node[:sphinx][:utility_name])       
+      # create sphinx directory
+      directory "#{shared_path}/sphinx" do
+        owner node[:owner_name]
+        group node[:owner_name]
+      end
+      
+      # remove sphinx dir
+      directory "#{current_path}/db/sphinx" do
+        action :delete
+        recursive true
+        only_if "test -d #{current_path}/db/sphinx"
+      end
+    
+      # symlink
+      link "#{current_path}/db/sphinx" do
+        to "#{shared_path}/sphinx"
+      end
+      
+      # install bundler if not present
+      gem_package "bundler" do
+        action :install
+        not_if "gem list | grep bundler"
+      end
+    
+      # configure thinking sphinx
+      execute "configure sphinx" do 
+        command "cd #{current_path} && bundle exec rake ts:configure"
+        user node[:owner_name]
+        environment 'RAILS_ENV' => env
+      end
+    
+      # index unless index already exists
+      execute "indexing" do
+        command "cd #{current_path} && bundle exec rake ts:index"
+        user node[:owner_name]
+        environment 'RAILS_ENV' => env
+      end
+    end
+  else
+    Chef::Log.info "Thinking Sphinx was not configured because the application (#{app_name}) must be deployed first. Please deploy your application and then re-run the custom chef recipes."
+  end
+end

--- a/cookbooks/thinking-sphinx-3/templates/default/sphinx.monitrc.erb
+++ b/cookbooks/thinking-sphinx-3/templates/default/sphinx.monitrc.erb
@@ -1,0 +1,5 @@
+check process sphinx_<%= @app_name %>
+  with pidfile <%= @pid_file %>
+  start program = "/usr/bin/searchd --pidfile --config /data/<%= @app_name %>/current/config/<%= @environment %>.sphinx.conf" as uid <%= @user %> and gid <%= @user %>
+  stop program = "/usr/bin/searchd --stopwait --config /data/<%= @app_name %>/current/config/<%= @environment %>.sphinx.conf" as uid <%= @user %> and gid <%= @user %>
+  group sphinx_<%= @app_name %>

--- a/cookbooks/thinking-sphinx-3/templates/default/thinking_sphinx.yml.erb
+++ b/cookbooks/thinking-sphinx-3/templates/default/thinking_sphinx.yml.erb
@@ -1,0 +1,4 @@
+<%= @environment %>:
+  address: <%= @address %>
+  mem_limit: 128M
+  pid_file: <%= @pid_file %>


### PR DESCRIPTION
Should work with TS 2.0 but I haven't tested.

Installs on application instances (including solos) if there is no utility instance that matches the name specified in the attributes, otherwise installs on specified utility instance.

If a new utility is added to a cluster, sphinx will be installed on that instance and removed from the application instances and vice versa.

Updates the indexer cronjob to call the indexer command directly and the monit config calls searchd directly speeding up start and stop times and indexing times.

No support for UltraSphinx because noone uses it. 

Tested on solos with utils and clusters with utils.
