### PR TITLE
Quote extension name for PostgreSQL extension installs

### DIFF
--- a/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
@@ -2,17 +2,20 @@ define :load_sql_file, :db_name => nil, :extname => nil, :supported_versions => 
   db_name = params[:db_name]
   extname = params[:extname]
   supported_versions = params[:supported_versions]
-  
-  Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions: (#{supported_versions}). PG version installed is #{@node[:postgres_version]}"
-  
+
+  Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions: #{supported_versions.join(", ")}. PG version installed is #{@node[:postgres_version]}"
+
   if @node[:postgres_version] == "9.0" && supported_versions.include?("9.0")
     execute "Postgresql loading contrib #{extname} on database #{db_name}" do
       command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
     end
   elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
-      execute "Postgresql loading extension #{extname}" do
-        command "psql -U postgres -d #{db_name} -c \"CREATE EXTENSION IF NOT EXISTS #{extname}\";"
-      end
+    execute "Postgresql loading extension #{extname}" do
+      command "psql -U postgres -d #{db_name} -c \"CREATE EXTENSION IF NOT EXISTS \\\"#{extname}\\\"\";"
+    end
+  elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
+    execute "Postgresql loading extension #{extname}" do
+      command "psql -U postgres -d #{db_name} -c \"CREATE EXTENSION IF NOT EXISTS \\\"#{extname}\\\"\";"
+    end
   end
-  
 end


### PR DESCRIPTION
Solves CC-440. Previously enabling any extension with a "minus" sign (-) failed because it wasn't being quoted on execution. The database was trying to perform a mathematical operation on it instead. Quoting the field solves this.
