### PR TITLE
properly quote the extension name so it actually installs

### DIFF
--- a/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
@@ -11,11 +11,11 @@ define :load_sql_file, :db_name => nil, :extname => nil, :supported_versions => 
     end
   elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
       execute "Postgresql loading extension #{extname}" do
-        command "psql -U postgres -d #{db_name} -c \"CREATE EXTENSION IF NOT EXISTS #{extname}\";"
+        command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
       end
   elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
       execute "Postgresql loading extension #{extname}" do
-        command "psql -U postgres -d #{db_name} -c \"CREATE EXTENSION IF NOT EXISTS #{extname}\";"
+        command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
       end
   end
 end


### PR DESCRIPTION
# Description of your patch

Properly quotes extension names when installing them to prevent extensions with hyphens or other characters in them from being interpreted by PostgreSQL. For example, "uuid-ossp" was failing to install because PostgreSQL was trying to subtract ossp from uuid.
# Estimated risk

Minimal; at worst the extensions won't install.
# Components involved

PostgreSQL, Chef
# Description of testing done

Tested on two independent clusters with PostgreSQL 9.2. ey recipes upload -e <whatever> --apply. Works in both cases. See no reason it wouldn't work on a PostgreSQL solo environment either.
# QA Instructions

[9.0, 9.1, 9.2].each do
  ey recipes upload -e <your env> --apply
  Verify no errors with chef
  Verify that extensions are created through PostgreSQL console
end
