### PR TITLE
Update the README file for the Sidekiq recipe

### DIFF
--- a/cookbooks/sidekiq/readme.md
+++ b/cookbooks/sidekiq/readme.md
@@ -55,7 +55,7 @@ You will need to add a deploy hook to restart Sidekiq during deploys. Add the fo
 
 ```
 on_utilities("sidekiq") do
-  sudo "monit restart all -g sidekiq_<app_name>"
+  sudo "monit restart all -g <app_name>_sidekiq"
 end
 ```
 
@@ -63,7 +63,7 @@ If Sidekiq is installed on your application instances, rather than a utility ins
 
 ```
 on_app_servers do
-  sudo "monit restart all -g sidekiq_<app_name>"
+  sudo "monit restart all -g <app_name>_sidekiq"
 end
 ```
 


### PR DESCRIPTION
In the README file for the Sidekiq recipe use to say that in order to restart the service, use the group name sidekiq_<app_name> and in the templates/defaults/sidekiq.monitrc.erb at the end the group is declare like this group <%= @app_name %>_sidekiq so I change the documentation file only.
