### PR TITLE
Updated contrib/extensions to not run against replicas

### DIFF
--- a/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
@@ -3,19 +3,21 @@ define :load_sql_file, :db_name => nil, :extname => nil, :supported_versions => 
   extname = params[:extname]
   supported_versions = params[:supported_versions]
 
-  Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions: #{supported_versions.join(", ")}. PG version installed is #{@node[:postgres_version]}"
-
-  if @node[:postgres_version] == "9.0" && supported_versions.include?("9.0")
-    execute "Postgresql loading contrib #{extname} on database #{db_name}" do
-      command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
+  if ['solo','db_master'].include?(@node[:instance_role])
+    Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions: #{supported_versions.join(", ")}. PG version installed is #{@node[:postgres_version]}"
+    
+    if @node[:postgres_version] == "9.0" && supported_versions.include?("9.0")
+      execute "Postgresql loading contrib #{extname} on database #{db_name}" do
+        command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
+      end
+    elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
+        execute "Postgresql loading extension #{extname}" do
+          command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
+        end
+    elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
+        execute "Postgresql loading extension #{extname}" do
+          command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
+        end
     end
-  elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
-      execute "Postgresql loading extension #{extname}" do
-        command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
-      end
-  elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
-      execute "Postgresql loading extension #{extname}" do
-        command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
-      end
   end
 end


### PR DESCRIPTION
Prevents errors like `cannot execute CREATE EXTENSION in a read-only transaction`
