### PR TITLE
set default mongodb version to 2.4.6, fix to :extra_opts handling (strin...

### DIFF
--- a/cookbooks/mongodb/attributes/default.rb
+++ b/cookbooks/mongodb/attributes/default.rb
@@ -1,4 +1,4 @@
-default[:mongo_version] = "2.2.0"
+default[:mongo_version] = "2.4.6"
 default[:mongo_path] = "/usr"
 default[:mongo_base] = "/data/mongodb"
 default[:mongo_port] = "27017"

--- a/cookbooks/mongodb/recipes/configure.rb
+++ b/cookbooks/mongodb/recipes/configure.rb
@@ -60,7 +60,7 @@ mongodb_options = { :exec => "#{mongodb_bin}/mongod",
                     :pid_path => "/var/run/mongodb",
                     :ip => "0.0.0.0",
                     :port => @node[:mongo_port],
-                    :extra_opts => [] }
+                    :extra_opts => '' }
 
 if @node[:mongo_journaling]
   mongodb_options[:extra_opts]  << " --journal"


### PR DESCRIPTION
set default mongodb version to 2.4.6, fix to :extra_opts handling (string, not array)

Fairly straightforward version bump to 2.4.6 and fixing the :extra_opts template var.

I tested booting 3 node replica sets on both stable-v3 and stable-v4 with these changes in place.
