### PR TITLE
Fix postgis2 installs, add release_version helper to main cookbook

### DIFF
--- a/cookbooks/main/libraries/release_version.rb
+++ b/cookbooks/main/libraries/release_version.rb
@@ -1,0 +1,9 @@
+class Chef
+  class Recipe
+    def release_version
+      release = File.read('/etc/engineyard/release')
+      return "v4" if release.to_i > 2009
+      "v2"
+    end
+  end
+end

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
@@ -2,7 +2,12 @@ if @node[:postgres_version] == "9.2"
   postgis_version = "2.0.2"
   proj_version = "4.6.1"
   geos_version = "3.2.2"
-  gdal_version = "1.8.1"
+
+  if release_version == "v2"
+    gdal_version = "1.8.1-r1"
+  else
+    gdal_version = "1.8.1-r2"
+  end
 
   package_use "sci-libs/geos" do
     flags "-ruby"
@@ -23,8 +28,14 @@ if @node[:postgres_version] == "9.2"
     version postgis_version
   end
 
-  package "dev-db/postgis" do
-    version postgis_version
+  # install gdal first so it gets installed via binary package instead of built
+  # from source with postgis below
+  package "sci-libs/gdal" do
+    version gdal_version
     action :install
+  end
+
+  execute "setting emerge options" do
+    command "emerge --ignore-default-opts dev-db/postgis"
   end
 end

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
@@ -22,15 +22,12 @@ if @node[:postgres_version] == "9.0"
     version postgis_version
     action :install
   end
-elsif ["9.1","9.2"].include?(@node[:postgres_version])
+  elsif ["9.1","9.2"].include?(@node[:postgres_version])
   if @node[:postgres_version] == "9.1"
     postgis_version = "1.5.3-r1"
   else
     postgis_version = "1.5.8"
   end
-
-  proj_version = "4.6.1"
-  geos_version = "3.2.2"
 
   package_use "sci-libs/geos" do
     flags "-ruby"


### PR DESCRIPTION
This is for DATA-287!

Emerge postgis manually

This avoids getting the binaries that may have been against the wrong Postgres
version.  Still need to emerge gdal via binary.

some minor formatting cleanup

adding lib file to main cookbook with release_version helper function

use different gdal ebuild for pre/post stable-v4
