### PR TITLE
Update papertrail recipe to work on both stable-v2 and stable-v4 stacks.

### DIFF
--- a/cookbooks/papertrail/templates/default/remote_syslog.initd.erb
+++ b/cookbooks/papertrail/templates/default/remote_syslog.initd.erb
@@ -9,7 +9,7 @@ start() {
     ebegin "Starting ${NAME}"
 
     start-stop-daemon --start --pidfile $PIDFILE --name $NAME \
-        --exec /usr/bin/remote_syslog -- $DAEMON_ARGS
+        --exec <%= @bin_path %>/remote_syslog -- $DAEMON_ARGS
 
     eend $?
 }
@@ -18,7 +18,7 @@ stop() {
     ebegin "Stopping ${NAME}"
 
     start-stop-daemon --stop --pidfile $PIDFILE --name $NAME \
-        --exec /usr/bin/remote_syslog
+        --exec <%= @bin_path %>/remote_syslog
 
     eend $?
 }


### PR DESCRIPTION
I just checked the recipe an a v2 and a v4 environments and they both worked, but you may want to make sure too.

Thanks to Christopher Rigor for the stack version detection code.
Check zendesk Request #70359 for additional background information.
