### PR TITLE
properly installs pg_stat_statements extension

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -130,10 +130,10 @@
   # postgresql9_pg_trgm "dbname"
   # postgresql9_pgcrypto "dbname"
   # postgresql9_pgrowlocks "dbname"
-  
+
   # PostGis 1.5 (use with versions 9.0, 9.1, 9.2)
   # postgresql9_postgis "dbname"
-  
+
   # PostGis 2.0 (use with versions >= 9.2)
   #postgresql9_postgis2 "dbname"
   # postgresql9_seg "dbname"
@@ -142,15 +142,16 @@
   # postgresql9_test_parser "dbname"
   # postgresql9_unaccent "dbname"
   # postgresql9_uuid_ossp "dbname"
-  
-  
+
+
   # 9.1 and 9.2 Extensions
   # postgresql9_file_fdw "dbname"
   # postgresql9_xml2 "dbname"
-  
-  #9.2 Extensions
+
+  # 9.2 Extensions
+  # Note: pg_stat_statements requires a server restart to complete installation
   # postgresql9_pg_stat_statements "dbname"
-  
+
   # Admin-Level Contribs
   # postgresql9_pg_buffercache "postgres"
   # postgresql9_pg_freespacemap "postgres"

--- a/cookbooks/postgresql9_extensions/README.md
+++ b/cookbooks/postgresql9_extensions/README.md
@@ -246,6 +246,18 @@ extension applied to.
 
 ``postgresql9_pgrowlocks "dbname""``
 
+##pg_stat_statements
+###supported versions: 9.2 - Note that pg_stat_statements requires a server restart to complete installation
+
+The pg_stat_statements module provides a means for tracking execution statistics of all SQL statements executed by a server.
+
+Enabling this extension:
+
+* Edit main/recipes/default.rb and comment out the line shown below. Replace dbname with the name of the database you want this
+extension applied to.
+
+``postgresql9_pg_stat_statements "dbname""``
+
 ##PostGIS 1.5
 ###supported versions: >= 9.0
 This extension adds support for geographic objects. PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend spatial database for geographic information systems (GIS).

--- a/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
@@ -6,4 +6,19 @@ define :postgresql9_pg_stat_statements do
     extname "pg_stat_statements"
     minimum_version 9.2
   end
+
+  #add shared_preload_libraries and pg_stat_statements to custom pgconf
+  p = "/db/postgresql/#{@node[:postgres_version]}/custom.conf"
+  ext_name = "pg_stat_statements"
+  update_file "add #{ext_name} to #{p}" do
+    action :append
+    path p
+    body <<-EOF
+shared_preload_libraries = 'pg_stat_statements'
+
+pg_stat_statements.max = 10000
+pg_stat_statements.track = all
+EOF
+    not_if "grep '#{ext_name}' #{p}"
+  end
 end

--- a/cookbooks/postgresql9_extensions/recipes/ext_autoexplain.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_autoexplain.rb
@@ -24,7 +24,7 @@ template "#{@node[:postgres_root]}#{@node[:postgres_version]}/custom_autoexplain
   })
 end
 
-execute "restarting postgres service" do
+execute "reload postgres service" do
   command "/etc/init.d/postgresql-#{@node[:postgres_version]} reload"
 end
 


### PR DESCRIPTION
* Adds needed the config params needed to properly enable the pg_stat_statements extension
* Restarts the db process to complete the extension enabling
* Adds warnings in documentation that the extension requires a process restart