### PR TITLE
Start sidekiq as a daemon so it logs errors to the logfile

### DIFF
--- a/cookbooks/sidekiq/templates/default/sidekiq.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.erb
@@ -53,7 +53,7 @@ start ()
   fi
   
   # start sidekiq
-  sidekiq -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" &
+  sidekiq -d -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}"
   exit $?
 }
 


### PR DESCRIPTION
Using `-d` is better than using `&` to background the process because stdout and
stderr get lost if we do it that way.
