### PR TITLE
Updated postgres version attributes to support future major versions, and general associated cleanup.

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -104,7 +104,7 @@
 
 #enable Extension modules for a given Postgresql database
 # if ['solo','db_master', 'db_slave'].include?(node[:instance_role])
-  # Extensions that support both Postgres 9.0, 9.1 and 9.2
+  # Extensions that support Postgres >= 9.0
   # postgresql9_autoexplain "dbname"
   # postgresql9_btree_gin "dbname"
   # postgresql9_btree_gist "dbname"
@@ -124,28 +124,28 @@
   # postgresql9_pg_trgm "dbname"
   # postgresql9_pgcrypto "dbname"
   # postgresql9_pgrowlocks "dbname"
-
+  
   # PostGis 1.5 (use with versions 9.0, 9.1, 9.2)
   # postgresql9_postgis "dbname"
-
-  # PostGis 2.0 (use with version 9.2)
-  # postgresql9_postgis2 "dbname"
+  
+  # PostGis 2.0 (use with versions >= 9.2)
+  #postgresql9_postgis2 "dbname"
   # postgresql9_seg "dbname"
   # postgresql9_sslinfo "dbname"
   # postgresql9_tablefunc "dbname"
   # postgresql9_test_parser "dbname"
   # postgresql9_unaccent "dbname"
   # postgresql9_uuid_ossp "dbname"
-
-
+  
+  
   # 9.1 and 9.2 Extensions
   # postgresql9_file_fdw "dbname"
   # postgresql9_xml2 "dbname"
-
-  # 9.2 Extensions
+  
+  #9.2 Extensions
   # postgresql9_pg_stat_statements "dbname"
-
-  #Admin-Level Contribs
+  
+  # Admin-Level Contribs
   # postgresql9_pg_buffercache "postgres"
   # postgresql9_pg_freespacemap "postgres"
-#end
+# end

--- a/cookbooks/postgresql9_extensions/README.md
+++ b/cookbooks/postgresql9_extensions/README.md
@@ -1,8 +1,7 @@
 ey-cloud-recipes/postgresql9_extensions
 ------------------------------------------------------------------------------
 
-A chef recipe for enabling Postgres extensions (contribs on Postgres 9.0) packages on Engine Yard Cloud.  This recipe defines multiple methods that
-can be called from main/recipes/default.rb to enable extensions for a given database.
+A chef recipe for enabling Postgres extensions (contribs on Postgres 9.0) packages on Engine Yard Cloud.  This recipe defines multiple methods that can be called from main/recipes/default.rb to enable extensions for a given database. More information on these extensions can be found in Appendix F of the PostgreSQL manual: http://www.postgresql.org/docs/9.3/static/contrib.html
 
 
 Dependencies
@@ -15,9 +14,9 @@ Available Extensions
 At the moment the following extensions are available.
 
 ##auto_explain
-###supported versions: 9.0, 9.1, 9.2
-This extension provides a means for logging execution plans of slow statements automatically, without having to run EXPLAIN by hand.
-This is especially helpful for tracking down un-optimized queries in large applications.
+###supported versions: >= 9.0
+This extension provides a means for logging execution plans of slow statements automatically, without having to run EXPLAIN by hand. This is especially helpful for tracking down un-optimized queries in large applications.
+
 WARNING: Enabling this extension will restart your Postgres service.
 
 Enabling this extension:
@@ -28,7 +27,7 @@ extension applied to.
 ``postgresql9_autoexplain "dbname""``
 
 ##btree_gin
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 This extension provides support for indexing common datatypes in GIN
 
 Enabling this extension:
@@ -38,20 +37,8 @@ extension applied to.
 
 ``postgresql9_btree_gin "dbname""``
 
-##intarray
-###supported versions: 9.0, 9.1
-The intarray module provides a number of useful functions and operators for manipulating null-free arrays of integers. There is also support for indexed searches using some of the operators.
-
-Enabling this extension:
-
-* Edit main/recipes/default.rb and comment out the line shown below. Replace dbname with the name of the database you want this
-extension applied to.
-
-``postgresql9_intarray "dbname""``
-
-
 ##btree_gist
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 This extension provides support for indexing common datatypes in GiST
 
 Enabling this extension:
@@ -61,11 +48,9 @@ extension applied to.
 
 ``postgresql9_btree_gist "dbname""``
 
-
 ##chkpass
-###supported versions: 9.0, 9.1, 9.2
-This extension implements a data type chkpass that is designed for storing encrypted passwords. Each password is automatically converted
-to encrypted form upon entry, and is always stored encrypted.
+###supported versions: >= 9.0
+This extension implements a data type chkpass that is designed for storing encrypted passwords. Each password is automatically converted to encrypted form upon entry, and is always stored encrypted.
 
 Enabling this extension:
 
@@ -74,11 +59,9 @@ extension applied to.
 
 ``postgresql9_chkpass "dbname""``
 
-
 ##citext
-###supported versions: 9.0, 9.1, 9.2
-The citext module provides a case-insensitive character string type, citext. Essentially, it internally calls lower when comparing values.
-Otherwise, it behaves almost exactly like text. (This is great for MySQL compatibility which does text comparisons case-insensitive, by default)
+###supported versions: >= 9.0
+The citext module provides a case-insensitive character string type, citext. Essentially, it internally calls lower when comparing values. Otherwise, it behaves almost exactly like text. (This is great for MySQL compatibility which does text comparisons case-insensitive, by default)
 
 Enabling this extension:
 
@@ -87,9 +70,8 @@ extension applied to.
 
 ``postgresql9_citext "dbname""``
 
-
 ##cube
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 This module implements a data type cube for representing multidimensional cubes.
 
 Enabling this extension:
@@ -99,9 +81,8 @@ extension applied to.
 
 ``postgresql9_cube "dbname""``
 
-
 ##dblink
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 dblink is a module which supports connections to other PostgreSQL databases from within a database session.
 
 Enabling this extension:
@@ -112,7 +93,7 @@ extension applied to.
 ``postgresql9_dblink "dbname""``
 
 ##dict_int
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 dict_int is an example of an add-on dictionary template for full-text search. The motivation for this example dictionary is to control the indexing of integers (signed and unsigned), allowing such numbers to be indexed while preventing excessive growth in the number of unique words, which greatly affects the performance of searching.
 
 Enabling this extension:
@@ -123,7 +104,7 @@ extension applied to.
 ``postgresql9_dict_int "dbname""``
 
 ##dict_xsyn
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 dict_xsyn (Extended Synonym Dictionary) is an example of an add-on dictionary template for full-text search. This dictionary type replaces words with groups of their synonyms, and so makes it possible to search for a word using any of its synonyms.
 
 Enabling this extension:
@@ -133,9 +114,8 @@ extension applied to.
 
 ``postgresql9_dict_xsyn "dbname""``
 
-
 ##earthdistance
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The earthdistance module provides two different approaches to calculating great circle distances on the surface of the Earth.
 
 Enabling this extension:
@@ -145,9 +125,8 @@ extension applied to.
 
 ``postgresql9_earthdistance "dbname""``
 
-
 ##file_fdw
-###supported versions: 9.1, 9.2
+###supported versions: >= 9.1
 The file fdw module provides the foreign-data wrapper, which can be used to access data files in the server's file system. Data files must be in a format that can be read by COPY FROM;
 
 Enabling this extension:
@@ -157,9 +136,8 @@ extension applied to.
 
 ``postgresql9_file_fdw "dbname""``
 
-
 ##fuzzystrmatch
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The fuzzystrmatch module provides several functions to determine similarities and distance between strings.
 
 Enabling this extension:
@@ -169,12 +147,9 @@ extension applied to.
 
 ``postgresql9_fuzzystrmatch "dbname""``
 
-
 ##hstore
-###supported versions: 9.0, 9.1, 9.2
-This module implements the hstore data type for storing sets of key/value pairs within a single PostgreSQL value. This can be useful
-in various scenarios, such as rows with many attributes that are rarely examined, or semi-structured data. Keys and values are simply
-text strings.
+###supported versions: >= 9.0
+This module implements the hstore data type for storing sets of key/value pairs within a single PostgreSQL value. This can be useful in various scenarios, such as rows with many attributes that are rarely examined, or semi-structured data. Keys and values are simply text strings.
 
 Enabling this extension:
 
@@ -184,7 +159,7 @@ extension applied to.
 ``postgresql9_hstore "dbname""``
 
 ##intarray
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The intarray module provides a number of useful functions and operators for manipulating null-free arrays of integers. There is also support for indexed searches using some of the operators.
 
 Enabling this extension:
@@ -194,11 +169,9 @@ extension applied to.
 
 ``postgresql9_intarray "dbname""``
 
-
 ##isn
-###supported versions: 9.0, 9.1, 9.2
-The isn module provides data types for the following international product numbering standards: EAN13, UPC, ISBN (books), ISMN (music),
-and ISSN (serials). Numbers are validated on input, and correctly hyphenated on output.
+###supported versions: >= 9.0
+The isn module provides data types for the following international product numbering standards: EAN13, UPC, ISBN (books), ISMN (music), and ISSN (serials). Numbers are validated on input, and correctly hyphenated on output.
 
 Enabling this extension:
 
@@ -207,9 +180,8 @@ extension applied to.
 
 ``postgresql9_isn "dbname""``
 
-
 ##lo
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The lo module provides support for managing Large Objects (also called LOs or BLOBs). This includes a data type lo and a trigger lo_manage.
 
 Enabling this extension:
@@ -219,11 +191,9 @@ extension applied to.
 
 ``postgresql9_lo "dbname""``
 
-
 ##ltree
-###supported versions: 9.0, 9.1
-This module implements a data type ltree for representing labels of data stored in a hierarchical tree-like structure. Extensive facilities
-for searching through label trees are provided.
+###supported versions: >= 9.0
+This module implements a data type ltree for representing labels of data stored in a hierarchical tree-like structure. Extensive facilities for searching through label trees are provided.
 
 Enabling this extension:
 
@@ -232,8 +202,19 @@ extension applied to.
 
 ``postgresql9_ltree "dbname""``
 
+##pg_stat_statements
+###supported versions: >= 9.2
+The pg_stat_statements module provides a means for tracking execution statistics of all SQL statements executed by a server.
+
+Enabling this extension:
+
+* Edit main/recipes/default.rb and comment out the line shown below. Replace dbname with the name of the database you want this
+extension applied to.
+
+``postgresql9_pg_stat_statements "dbname""``
+
 ##pg_trgm
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The pg_trgm module provides GiST and GIN index operator classes that allow you to create an index over a text column for the purpose of very fast similarity searches. These index types support the above-described similarity operators, and additionally support trigram-based index searches for LIKE and ILIKE queries. (These indexes do not support equality nor simple comparison operators, so you may need a regular B-tree index too.).
 
 Enabling this extension:
@@ -244,7 +225,7 @@ extension applied to.
 ``postgresql9_pg_trgm "dbname""``
 
 ##pgcrypto
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The pgcrypto module provides cryptographic functions for PostgreSQL.
 
 Enabling this extension:
@@ -254,9 +235,8 @@ extension applied to.
 
 ``postgresql9_pgcrypto "dbname""``
 
-
 ##pgrowlocks
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 The pgrowlocks module provides a function to show row locking information for a specified table.
 
 Enabling this extension:
@@ -266,21 +246,9 @@ extension applied to.
 
 ``postgresql9_pgrowlocks "dbname""``
 
-##pg_stat_statements
-###supported versions: 9.2
-The pg_stat_statements module provides a means for tracking execution statistics of all SQL statements executed by a server.
-
-Enabling this extension:
-
-* Edit main/recipes/default.rb and comment out the line shown below. Replace dbname with the name of the database you want this
-extension applied to.
-
-``postgresql9_pg_stat_statements "dbname""``
-
 ##PostGIS 1.5
-###supported versions: 9.0, 9.1, 9.2
-This extension adds support for geographic objects. PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend
-spatial database for geographic information systems (GIS).
+###supported versions: >= 9.0
+This extension adds support for geographic objects. PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend spatial database for geographic information systems (GIS).
 
 Enabling this extension:
 
@@ -289,11 +257,9 @@ extension applied to.
 
 ``postgresql9_postgis "dbname""``
 
-
 ##PostGIS 2.0
-###supported versions: 9.2
-This extension adds support for geographic objects. PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend
-spatial database for geographic information systems (GIS).
+###supported versions: >= 9.2
+This extension adds support for geographic objects. PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend spatial database for geographic information systems (GIS).
 
 Enabling this extension:
 
@@ -303,9 +269,8 @@ extension applied to.
 ``postgresql9_postgis2 "dbname""``
 
 ##seg
-###supported versions: 9.0, 9.1, 9.2
-This module implements a data type seg for representing line segments, or floating point intervals. seg can represent uncertainty in the
-interval endpoints, making it especially useful for representing laboratory measurements.
+###supported versions: >= 9.0
+This module implements a data type seg for representing line segments, or floating point intervals. seg can represent uncertainty in the interval endpoints, making it especially useful for representing laboratory measurements.
 
 Enabling this extension:
 
@@ -314,9 +279,8 @@ extension applied to.
 
 ``postgresql9_seg "dbname""``
 
-
 ##sslinfo
-###supported versions: 9.0, 9.1
+###supported versions: >= 9.0
 The sslinfo module provides information about the SSL certificate that the current client provided when connecting to PostgreSQL. The module is useless (most functions will return NULL) if the current connection does not use SSL.
 
 Enabling this extension:
@@ -327,9 +291,8 @@ extension applied to.
 ``postgresql9_sslinfo "dbname""``
 
 ##tablefunc
-###supported versions: 9.0, 9.1, 9.2
-The tablefunc module includes various functions that return tables (that is, multiple rows). These functions are useful both in their own
-right and as examples of how to write C functions that return multiple rows.
+###supported versions: >= 9.0
+The tablefunc module includes various functions that return tables (that is, multiple rows). These functions are useful both in their own right and as examples of how to write C functions that return multiple rows.
 
 Enabling this extension:
 
@@ -338,9 +301,8 @@ extension applied to.
 
 ``postgresql9_tablefunc "dbname""``
 
-
 ##test_parser
-###supported versions: 9.0, 9.1, 9.2
+###supported versions: >= 9.0
 test_parser is an example of a custom parser for full-text search. It doesn't do anything especially useful, but can serve as a starting point for developing your own parser.
 
 Enabling this extension:
@@ -350,12 +312,9 @@ extension applied to.
 
 ``postgresql9_test_parser "dbname""``
 
-
 ##unaccent
-###supported versions: 9.0, 9.1
-unaccent is a text search dictionary that removes accents (diacritic signs) from lexemes. It's a filtering dictionary, which means its output
-is always passed to the next dictionary (if any), unlike the normal behavior of dictionaries. This allows accent-insensitive processing for
-full text search.
+###supported versions: >= 9.0
+unaccent is a text search dictionary that removes accents (diacritic signs) from lexemes. It's a filtering dictionary, which means its output is always passed to the next dictionary (if any), unlike the normal behavior of dictionaries. This allows accent-insensitive processing for full text search.
 
 Enabling this extension:
 
@@ -364,12 +323,9 @@ extension applied to.
 
 ``postgresql9_unaccent "dbname""``
 
-
 ##uuid-ossp
-###supported versions: 9.0, 9.1, 9.2
-The uuid-ossp module provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms. There are
-also functions to produce certain special UUID constants. (This also requires a separate USE flag when building the postgres binaries that pulls
-in another package.)
+###supported versions: >= 9.0
+The uuid-ossp module provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms. There are also functions to produce certain special UUID constants. (This also requires a separate USE flag when building the postgres binaries that pulls in another package.)
 
 Enabling this extension:
 
@@ -379,10 +335,8 @@ extension applied to.
 ``postgresql9_uuid_ossp "dbname""``
 
 ##xml2
-###supported versions: 9.1, 9.2
-The uuid-ossp module provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms. There are
-also functions to produce certain special UUID constants. (This also requires a separate USE flag when building the postgres binaries that pulls
-in another package.)
+###supported versions: >= 9.1
+The uuid-ossp module provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms. There are also functions to produce certain special UUID constants. (This also requires a separate USE flag when building the postgres binaries that pulls in another package.)
 
 Enabling this extension:
 
@@ -397,7 +351,7 @@ Admin-level Contrib packages
 Notes: This module requires a privileged user. Please log in as the postgres user to use the extension
 
 ##pg_buffercache
-###supported versions: 9.0, 9.2
+###supported versions: >= 9.0
 The pg_buffercache module provides a means for examining what's happening in the shared buffer cache in real time.
 
 Enabling this Module:
@@ -406,12 +360,9 @@ Enabling this Module:
 
 ``postgresql9_pg_buffercache "postgres""``
 
-
 ##pg_freespacemap
-###supported versions: 9.0, 9.2
-The pg_freespacemap module provides a means for examining the free space map (FSM). It provides a function called pg_freespace,
-or two overloaded functions, to be precise. The functions show the value recorded in the free space map for a given page, or for all
-pages in the relation.
+###supported versions: >= 9.0
+The pg_freespacemap module provides a means for examining the free space map (FSM). It provides a function called pg_freespace, or two overloaded functions, to be precise. The functions show the value recorded in the free space map for a given page, or for all pages in the relation.
 
 Enabling this Module:
 
@@ -454,4 +405,4 @@ None so far.
 
 Credits
 --------
-Thanks to Erik Jones, Scott Likens, Joel Watson, Edward Muller, and Jayson Vantuyl for their help.
+Thanks to Erik Jones, Scott Likens, Joel Watson, Edward Muller, Ines Sombra, Tyler Poland, and Jayson Vantuyl for their help.

--- a/cookbooks/postgresql9_extensions/attributes/default.rb
+++ b/cookbooks/postgresql9_extensions/attributes/default.rb
@@ -2,9 +2,7 @@ default[:db_stack] = db_stack = node[:engineyard][:environment][:db_stack_name]
 default[:postgres_root] = "/db/postgresql/"
 
 if db_stack == "postgres9"
-  default[:postgres_version] = "9.0"
-elsif db_stack == "postgres9_1"
-  default[:postgres_version] = "9.1"
-elsif db_stack == "postgres9_2"
-  default[:postgres_version] = "9.2"
+  default[:postgres_version] = 9.0
+elsif db_stack =~ /postgres\d+_\d+/
+  default[:postgres_version] = db_stack.gsub('postgres','').gsub('_','.').to_f
 end

--- a/cookbooks/postgresql9_extensions/definitions/auto_explain.rb
+++ b/cookbooks/postgresql9_extensions/definitions/auto_explain.rb
@@ -4,7 +4,7 @@ define :postgresql9_autoexplain do
  load_shared_library do
     db_name dbname_to_use
     library_name "auto_explain"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 
   include_recipe "postgresql9_extensions::ext_autoexplain"

--- a/cookbooks/postgresql9_extensions/definitions/btree_gin.rb
+++ b/cookbooks/postgresql9_extensions/definitions/btree_gin.rb
@@ -5,6 +5,6 @@ define :postgresql9_btree_gin do
     db_name dbname_to_use
     username "postgres"
     extname "btree_gin"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/btree_gist.rb
+++ b/cookbooks/postgresql9_extensions/definitions/btree_gist.rb
@@ -5,6 +5,6 @@ define :postgresql9_btree_gist do
     db_name dbname_to_use
     username "postgres"
     extname "btree_gist"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/chkpass.rb
+++ b/cookbooks/postgresql9_extensions/definitions/chkpass.rb
@@ -5,6 +5,6 @@ define :postgresql9_chkpass do
     db_name dbname_to_use
     username "postgres"
     extname "chkpass"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/citext.rb
+++ b/cookbooks/postgresql9_extensions/definitions/citext.rb
@@ -4,6 +4,6 @@ define :postgresql9_citext do
   load_sql_file do
     db_name dbname_to_use
     extname "citext"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/cube.rb
+++ b/cookbooks/postgresql9_extensions/definitions/cube.rb
@@ -4,6 +4,6 @@ define :postgresql9_cube do
   load_sql_file do
     db_name dbname_to_use
     extname "cube"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/dblink.rb
+++ b/cookbooks/postgresql9_extensions/definitions/dblink.rb
@@ -4,6 +4,6 @@ define :postgresql9_dblink do
   load_sql_file do
     db_name dbname_to_use
     extname "dblink"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/dict_int.rb
+++ b/cookbooks/postgresql9_extensions/definitions/dict_int.rb
@@ -4,6 +4,6 @@ define :postgresql9_dict_int do
   load_sql_file do
     db_name dbname_to_use
     extname "dict_int"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/dict_xsyn.rb
+++ b/cookbooks/postgresql9_extensions/definitions/dict_xsyn.rb
@@ -4,6 +4,6 @@ define :postgresql9_dict_xsyn do
   load_sql_file do
     db_name dbname_to_use
     extname "dict_xsyn"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/earthdistance.rb
+++ b/cookbooks/postgresql9_extensions/definitions/earthdistance.rb
@@ -4,6 +4,6 @@ define :postgresql9_earthdistance do
   load_sql_file do
     db_name dbname_to_use
     extname "earthdistance"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/file_fdw.rb
+++ b/cookbooks/postgresql9_extensions/definitions/file_fdw.rb
@@ -4,6 +4,6 @@ define :postgresql9_file_fdw do
   load_sql_file do
     db_name dbname_to_use
     extname "file_fdw"
-    supported_versions %w[9.1 9.2]
+    minimum_version 9.1
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/fuzzystrmatch.rb
+++ b/cookbooks/postgresql9_extensions/definitions/fuzzystrmatch.rb
@@ -4,6 +4,6 @@ define :postgresql9_fuzzystrmatch do
   load_sql_file do
     db_name dbname_to_use
     extname "fuzzystrmatch"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/hstore.rb
+++ b/cookbooks/postgresql9_extensions/definitions/hstore.rb
@@ -4,6 +4,6 @@ define :postgresql9_hstore do
   load_sql_file do
     db_name dbname_to_use
     extname "hstore"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/intarray.rb
+++ b/cookbooks/postgresql9_extensions/definitions/intarray.rb
@@ -4,6 +4,6 @@ define :postgresql9_intarray do
   load_sql_file do
     db_name dbname_to_use
     extname "intarray"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/isn.rb
+++ b/cookbooks/postgresql9_extensions/definitions/isn.rb
@@ -4,6 +4,6 @@ define :postgresql9_isn do
   load_sql_file do
     db_name dbname_to_use
     extname "isn"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/lo.rb
+++ b/cookbooks/postgresql9_extensions/definitions/lo.rb
@@ -4,6 +4,6 @@ define :postgresql9_lo do
   load_sql_file do
     db_name dbname_to_use
     extname "lo"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/load_shared_library.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_shared_library.rb
@@ -1,19 +1,20 @@
-define :load_shared_library, :db_name => nil, :library_name => nil, :supported_versions => nil do
+define :load_shared_library, :db_name => nil, :library_name => nil, :minimum_version => nil do
   library_name = params[:library_name]
   db_name = params[:db_name]
-  supported_versions = params[:supported_versions]
-
-  if @node[:postgres_version] == "9.0" && supported_versions.include?("9.0")
-    execute "Postgresql loading library #{library_name}" do
-      command "psql -U postgres -d #{db_name} -c \"LOAD \'#{library_name}\'\";"
-    end
-  elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
-    execute "Postgresql loading library #{library_name}" do
-      command "psql -U postgres -d #{db_name} -c \"LOAD \'#{library_name}\'\";"
-    end
-  elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
-    execute "Postgresql loading library #{library_name}" do
-      command "psql -U postgres -d #{db_name} -c \"LOAD \'#{library_name}\'\";"
+  minimum_version = params[:minimum_version].to_f
+  
+  Chef::Log.info "Loading to database #{db_name} library #{library_name} supported on versions higher than: #{minimum_version}. PG version installed is #{@node[:postgres_version]}"
+  
+  # we ensure a minimum version is set, the version selected is at least the minimum version
+  if not minimum_version.nil? && @node[:postgres_version] >= minimum_version
+    # now we ensure the install syntax is appropriate for this version
+    if @node[:postgres_version] == 0.0
+      # we skip this
+    # elsif @node[:postgres_version].to_f >= [some future revision where syntax changes]
+    elsif @node[:postgres_version] >= 9.0
+      execute "Postgresql loading library #{library_name}" do
+        command "psql -U postgres -d #{db_name} -c \"LOAD \'#{library_name}\'\";"
+      end
     end
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
@@ -1,23 +1,26 @@
-define :load_sql_file, :db_name => nil, :extname => nil, :supported_versions => nil do
+define :load_sql_file, :db_name => nil, :extname => nil, :minimum_version => nil do
   db_name = params[:db_name]
   extname = params[:extname]
-  supported_versions = params[:supported_versions]
+  minimum_version = params[:minimum_version].to_f
 
   if ['solo','db_master'].include?(@node[:instance_role])
-    Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions: #{supported_versions.join(", ")}. PG version installed is #{@node[:postgres_version]}"
+    Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions higher than: #{minimum_version}. PG version installed is #{@node[:postgres_version]}"
     
-    if @node[:postgres_version] == "9.0" && supported_versions.include?("9.0")
-      execute "Postgresql loading contrib #{extname} on database #{db_name}" do
-        command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
+    # we ensure a minimum version is set, the version selected is at least the minimum version
+    if not minimum_version.nil? && @node[:postgres_version] >= minimum_version
+      # now we ensure the install syntax is appropriate for this version
+      if @node[:postgres_version] == 0.0
+        # we skip this
+      # elsif @node[:postgres_version].to_f >= [some future revision where syntax changes]
+      elsif @node[:postgres_version] >= 9.1
+        execute "Postgresql loading extension #{extname}" do
+          command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
+        end
+      elsif @node[:postgres_version] >= 9.0
+        execute "Postgresql loading contrib #{extname} on database #{db_name}" do
+          command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
+        end
       end
-    elsif @node[:postgres_version] == "9.1" && supported_versions.include?("9.1")
-        execute "Postgresql loading extension #{extname}" do
-          command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
-        end
-    elsif @node[:postgres_version] == "9.2" && supported_versions.include?("9.2")
-        execute "Postgresql loading extension #{extname}" do
-          command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
-        end
     end
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/ltree.rb
+++ b/cookbooks/postgresql9_extensions/definitions/ltree.rb
@@ -4,6 +4,6 @@ define :postgresql9_ltree do
   load_sql_file do
     db_name dbname_to_use
     extname "ltree"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pg_buffercache.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_buffercache.rb
@@ -4,6 +4,6 @@ define :postgresql9_pg_buffercache do
   load_sql_file do
     db_name dbname_to_use
     extname "pg_buffercache"
-    supported_versions %w[9.0 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pg_freespacemap.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_freespacemap.rb
@@ -4,6 +4,6 @@ define :postgresql9_pg_freespacemap do
   load_sql_file do 
     db_name dbname_to_use
     extname "pg_freespacemap"
-    supported_versions %w[9.0 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
@@ -4,6 +4,6 @@ define :postgresql9_pg_stat_statements do
   load_sql_file do
     db_name dbname_to_use
     extname "pg_stat_statements"
-    supported_versions %w[9.2]
+    minimum_version 9.2
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pg_trgm.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_trgm.rb
@@ -4,6 +4,6 @@ define :postgresql9_pg_trgm do
   load_sql_file do 
     db_name dbname_to_use
     extname "pg_trgm"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pgcrypto.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pgcrypto.rb
@@ -4,6 +4,6 @@ define :postgresql9_pgcrypto do
   load_sql_file do 
     db_name dbname_to_use
     extname "pgcrypto"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/pgrowlocks.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pgrowlocks.rb
@@ -4,6 +4,6 @@ define :postgresql9_pgrowlocks do
   load_sql_file do
     db_name dbname_to_use
     extname "pgrowlocks"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/postgis.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis.rb
@@ -1,49 +1,54 @@
 define :postgresql9_postgis do
   dbname_to_use = params[:name]
-  include_recipe "postgresql9_extensions::ext_postgis_install"
-
-  if ['solo','db_master'].include?(@node[:instance_role])
-    if @node[:postgres_version] == "9.0"
+  
+  if @node[:postgres_version] >= 9.3
+    Chef::Log.info "Postgis 1.5 is not supported on versions 9.3 and higher; your current version is #{@node[:postgres_version]}. Please use the postgis2 extension instead."
+  else
+    include_recipe "postgresql9_extensions::ext_postgis_install"
+    
+    if ['solo','db_master'].include?(@node[:instance_role])
+      if @node[:postgres_version] == 9.0
+        
+          load_sql_file do
+            db_name dbname_to_use
+            minimum_version 9.0
+            extname "postgis-1.5/postgis"
+          end
       
-        load_sql_file do
-          db_name dbname_to_use
-          supported_versions %w[9.0]
-          extname "postgis-1.5/postgis"
+          load_sql_file do
+            db_name dbname_to_use
+            minimum_version 9.0
+            extname "postgis-1.5/spatial_ref_sys"
+          end
+      
+          load_sql_file do
+            db_name dbname_to_use
+            minimum_version 9.0
+            extname"postgis-1.5/postgis_comments"
+          end
+      elsif @node[:postgres_version] >= 9.1
+        pgversion = @node[:postgres_version]
+      
+         execute "Postgresql loading postgis 1.5 on database #{dbname_to_use} for version #{pgversion}" do
+           command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis.sql"
+         end
+      
+        execute "Postgresql loading spatial_ref_sys on database #{dbname_to_use} for version #{pgversion}" do
+          command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/spatial_ref_sys.sql"
         end
-    
-        load_sql_file do
-          db_name dbname_to_use
-          supported_versions %w[9.0]
-          extname "postgis-1.5/spatial_ref_sys"
+      
+        execute "Postgresql loading postgis_comments on database #{dbname_to_use} for version #{pgversion}" do
+          command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis_comments.sql"
         end
-    
-        load_sql_file do
-          db_name dbname_to_use
-          supported_versions %w[9.0]
-          extname"postgis-1.5/postgis_comments"
-        end
-    elsif ["9.1","9.2"].include?(@node[:postgres_version])
-      pgversion = @node[:postgres_version]
-    
-       execute "Postgresql loading postgis 1.5 on database #{dbname_to_use} for version #{pgversion}" do
-         command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis.sql"
-       end
-    
-      execute "Postgresql loading spatial_ref_sys on database #{dbname_to_use} for version #{pgversion}" do
-        command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/spatial_ref_sys.sql"
       end
-    
-      execute "Postgresql loading postgis_comments on database #{dbname_to_use} for version #{pgversion}" do
-        command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis_comments.sql"
+      
+      execute "Grant permissions to the deploy user on the geometry_columns schema" do
+        command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on geometry_columns to deploy\""
       end
-    end
-    
-    execute "Grant permissions to the deploy user on the geometry_columns schema" do
-      command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on geometry_columns to deploy\""
-    end
-    
-    execute "Grant permissions to the deploy user on the spatial_ref_sys schema" do
-      command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on spatial_ref_sys to deploy\""
+      
+      execute "Grant permissions to the deploy user on the spatial_ref_sys schema" do
+        command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on spatial_ref_sys to deploy\""
+      end
     end
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/postgis2.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis2.rb
@@ -1,13 +1,13 @@
 define :postgresql9_postgis2 do
   dbname_to_use = params[:name]
 
-  if @node[:postgres_version] == "9.2"
+  if @node[:postgres_version] >= 9.2
     include_recipe "postgresql9_extensions::ext_postgis2_install"
     
     if ['solo','db_master'].include?(@node[:instance_role])
       load_sql_file do
         db_name dbname_to_use
-        supported_versions %w[9.2]
+        minimum_version 9.2
         extname "postgis"
       end
       

--- a/cookbooks/postgresql9_extensions/definitions/seg.rb
+++ b/cookbooks/postgresql9_extensions/definitions/seg.rb
@@ -4,6 +4,6 @@ define :postgresql9_seg do
   load_sql_file do
     db_name dbname_to_use
     extname "seg"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/sslinfo.rb
+++ b/cookbooks/postgresql9_extensions/definitions/sslinfo.rb
@@ -4,7 +4,7 @@ define :postgresql9_sslinfo do
   load_sql_file do 
     db_name dbname_to_use
     extname "sslinfo"
-    supported_versions %w[9.0 9.1]
+    minimum_version 9.0
   end
 
 end

--- a/cookbooks/postgresql9_extensions/definitions/tablefunc.rb
+++ b/cookbooks/postgresql9_extensions/definitions/tablefunc.rb
@@ -4,6 +4,6 @@ define :postgresql9_tablefunc do
   load_sql_file do
     db_name dbname_to_use
     extname "tablefunc"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/test_parser.rb
+++ b/cookbooks/postgresql9_extensions/definitions/test_parser.rb
@@ -4,6 +4,6 @@ define :postgresql9_test_parser do
   load_sql_file do
     db_name dbname_to_use
     extname "test_parser"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/unaccent.rb
+++ b/cookbooks/postgresql9_extensions/definitions/unaccent.rb
@@ -4,7 +4,7 @@ define :postgresql9_unaccent do
   load_sql_file do 
     db_name dbname_to_use
     extname "unaccent"
-    supported_versions %w[9.0 9.1]
+    minimum_version 9.0
   end
 
 end

--- a/cookbooks/postgresql9_extensions/definitions/uuid-ossp.rb
+++ b/cookbooks/postgresql9_extensions/definitions/uuid-ossp.rb
@@ -4,6 +4,6 @@ define :postgresql9_uuid_ossp do
   load_sql_file do
     db_name dbname_to_use
     extname "uuid-ossp"
-    supported_versions %w[9.0 9.1 9.2]
+    minimum_version 9.0
   end
 end

--- a/cookbooks/postgresql9_extensions/definitions/xml2.rb
+++ b/cookbooks/postgresql9_extensions/definitions/xml2.rb
@@ -4,6 +4,6 @@ define :postgresql9_xml2 do
   load_sql_file do
     db_name dbname_to_use
     extname "xml2"
-    supported_versions %w[9.1 9.2]
+    minimum_version 9.1
   end
 end

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
@@ -1,8 +1,8 @@
-if @node[:postgres_version] == "9.2"
-  postgis_version = "2.0.2"
+if @node[:postgres_version] >= 9.2
+  postgis_version = "2.1.1"
   proj_version = "4.6.1"
-  geos_version = "3.2.2"
-  gdal_version = "1.8.1"
+  geos_version = "3.4.2"
+  gdal_version = "1.10.0-r1"
 
   package_use "sci-libs/geos" do
     flags "-ruby"

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
@@ -1,4 +1,4 @@
-if @node[:postgres_version] == "9.0"
+if @node[:postgres_version] == 9.0
   postgis_version = "1.5.2"
   proj_version = "4.6.1"
   geos_version = "3.2.2"
@@ -22,8 +22,8 @@ if @node[:postgres_version] == "9.0"
     version postgis_version
     action :install
   end
-elsif ["9.1","9.2"].include?(@node[:postgres_version])
-  if @node[:postgres_version] == "9.1"
+elsif @node[:postgres_version] >= 9.1
+  if @node[:postgres_version] == 9.1
     postgis_version = "1.5.3-r1"
   else
     postgis_version = "1.5.8"
@@ -48,7 +48,7 @@ elsif ["9.1","9.2"].include?(@node[:postgres_version])
   end
 
   execute "setting emerge options" do
-    command "emerge --ignore-default-opts dev-db/postgis"
+    command "emerge --ignore-default-opts =dev-db/postgis-#{postgis_version}"
   end
 end
 

--- a/cookbooks/postgresql9_extensions/templates/default/custom_autoexplain.erb
+++ b/cookbooks/postgresql9_extensions/templates/default/custom_autoexplain.erb
@@ -13,6 +13,6 @@ auto_explain.log_buffers = <%= @auto_explain_log_buffers %>
 auto_explain.log_format = <%= @auto_explain_log_format  %>
 auto_explain.log_nested_statements = <%= @auto_explain_log_nested_statements  %>
 shared_preload_libraries = <%= @shared_preload_libraries %>
-<% if @db_version != "9.2" %>
+<% if @db_version < 9.2 %>
   custom_variable_classes = <%= @custom_variable_classes %>
 <% end %>


### PR DESCRIPTION
Tested against stable-v4 postgres 9.3 all cookbooks (postgis2)
Tested against stable-v2 postgres 9.3 all cookbooks (postgis2)
Tested against stable-v2 postgres 9.2 all cookbooks (postgis1)
