### PR TITLE
fix redis for v4, remove a rogue include_recipe in main cookbook recipe

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -102,7 +102,7 @@
 # To install a Jenkins environment, uncomment below
 # include_recipe "jenkins"
 
-include_recipe "eventmachine"
+# include_recipe "eventmachine"
 
 #enable Extension modules for a given Postgresql database
 # if ['solo','db_master', 'db_slave'].include?(node[:instance_role])

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -46,6 +46,13 @@ if ['util'].include?(node[:instance_role])
         :rdbcompression => node[:redis][:rdbcompression],
       })
     end
+    
+    # redis-server is in /usr/bin on stable-v2, /usr/sbin for stable-v4
+    if Chef::VERSION[/^0.6/]
+      bin_path = "/usr/bin/redis-server"
+    else
+      bin_path = "/usr/sbin/redis-server"
+    end  
 
     template "/data/monit.d/redis_util.monitrc" do
       owner 'root'
@@ -58,6 +65,7 @@ if ['util'].include?(node[:instance_role])
         :pidfile => node[:redis][:pidfile],
         :logfile => node[:redis][:basename],
         :port => node[:redis][:bindport],
+        :bin_path => bin_path
       })
     end
 

--- a/cookbooks/redis/templates/default/redis.monitrc.erb
+++ b/cookbooks/redis/templates/default/redis.monitrc.erb
@@ -1,5 +1,5 @@
 check process redis-<%= @profile %>
 with pidfile <%= @pidfile %>
-  start program = "/usr/bin/redis-server <%= @configfile %>"
+  start program = "<%= @bin_path %> <%= @configfile %>"
   stop program = "/usr/bin/redis-cli -p <%= @port %> shutdown"
   group redis-util


### PR DESCRIPTION
## Description of your patch

This patch fixes Redis under stable-v4, the path was incorrectly set.  I am checking the Chef version to determine this path as v2 should still be /usr/bin.

I also found a rogue include_recipe in the main cookbook recipe that caused chef to fail, I commented that out.  There is no risk in this change.
## Recommended Release Notes
- Fixes Redis binary location on stable-v4 environments.
## Estimated risk

Low.  We are just updating the binary path for redis-server depending on stack
## Components involved

Redis
## Description of testing done

I tested this on a v4 and v2 environment.  I booted up a standard cluster with a single utility instance named 'redis'
## QA Instructions

Boot up stable-v4 environment, 1 app, 1 db, 1 utility named 'redis'.  Make sure the Redis recipe is included in the main cookbook recipe, then upload and apply.  SSH into the redis utility instance and run 'monit summary' to verify that redis is running under monit.

Boot up stable-v2 environment, 1 app, 1 db, 1 utility named 'redis'.  Make sure the Redis recipe is included in the main cookbook recipe, then upload and apply.  SSH into the redis utility instance and run 'monit summary' to verify that redis is running under monit.
