### PR TITLE
redis-yml: render yml file on util and solo instances

### DIFF
--- a/cookbooks/redis-yml/recipes/default.rb
+++ b/cookbooks/redis-yml/recipes/default.rb
@@ -1,4 +1,4 @@
-if ['app_master', 'app'].include?(node[:instance_role])
+if ['app_master', 'app', 'solo', 'util'].include?(node[:instance_role])
 
   # If you have only one utility instance uncomment the line below
   #redis_instance = node['utility_instances'].first


### PR DESCRIPTION
```
Description of your patch
-------------
```

Render redis.yml on util and solo instances

```
Recommended Release Notes
-------------
```

Adds util and solo instances to the the list of instances where a redis.yml file is rendered

```
Estimated risk
-------------
```

Low

```
Components involved
-------------
```

Redis

```
Description of testing done
-------------
```

Booted up an environment with a solo environment, added util instance called 'redis', verified that the redis.yml file was rendered on the solo instance.

```
QA Instructions
-------------
```

Boot up an environment with a solo environment, add util instance called 'redis', verify that the redis.yml file was rendered on the solo instance.
