### PR TITLE
added cron cookbook

### DIFF
--- a/cookbooks/cron/README.md
+++ b/cookbooks/cron/README.md
@@ -1,0 +1,21 @@
+Cron Cookbook for Engine Yard Cloud
+===================================
+
+Overview
+--------
+This cookbook automates the installation of cron jobs on Engine Yard Cloud.  The cron jobs are added for the application user on the utility instance name specified for each cron job.  All cron jobs are specified in the attributes file of the cookbook.
+
+Specifics of Usage
+------------------
+Add your cron jobs as an array of hashes to attributes/cron.rb and uncomment the include_recipe in the main cookbook recipe.  You must specify a name, time, command and instance name.  The time value must be the full string containing minute, hour, day, month and weekday separated by spaces (eg: '* * * * *').
+
+Example Configuration:
+
+```
+default[:custom_crons] = [{:name => "test1", :time => "10 * * * *", :command => "echo 'test1'", :instance_name => "cron"},
+                          {:name => "test2", :time => "10 1 * * *", :command => "echo 'test2'", :instance_name => "cron"}]
+```
+
+Notes
+-----
+This cookbook will not install cron jobs for the root user, it must be modified if this is required.  Cron jobs are installed for the default application user, typically called deploy.

--- a/cookbooks/cron/attributes/cron.rb
+++ b/cookbooks/cron/attributes/cron.rb
@@ -1,0 +1,5 @@
+# Add one hash per cron job required
+# Set the utility instance name to install each cron job on via instance_name
+
+default[:custom_crons] = [{:name => "test1", :time => "10 * * * *", :command => "echo 'test1'", :instance_name => "cron"},
+                          {:name => "test2", :time => "10 1 * * *", :command => "echo 'test2'", :instance_name => "cron"}]

--- a/cookbooks/cron/recipes/default.rb
+++ b/cookbooks/cron/recipes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: cron
+# Recipe:: default
+#
+
+# Find all cron jobs specified in attributes/cron.rb where current node name matches instance_name
+crons = node[:custom_crons].find_all {|c| c[:instance_name].match "#{node[:name]}" }
+
+crons.each do |cron|
+  cron cron[:name] do
+    user     node['owner_name']
+    action   :create
+    minute   cron[:time].split[0]
+    hour     cron[:time].split[1]
+    day      cron[:time].split[2]
+    month    cron[:time].split[3]
+    weekday  cron[:time].split[4]
+    command  cron[:command]
+  end
+end

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -49,6 +49,10 @@
 # You must add your packages to packages/attributes/packages.rb
 #require_recipe "packages"
 
+#uncomment to add specified cron jobs for application user (deploy)
+# You must add your cron jobs to cron/attributes/cron.rb
+#require_recipe "cron"
+
 #uncomment to run the exim::auth recipe
 #include_recipe "exim::auth"
 #include_recipe "mongodb"


### PR DESCRIPTION
```
Description of your patch
-------------
```

This cookbook allows user to easily configure cron jobs in an attributes file.

```
Recommended Release Notes
-------------
```

Adds a cron cookbook that automates the installation of cron jobs based on the attributes in the cookbook.

```
Estimated risk
-------------
```

None

```
Components involved
-------------
```

Cron

```
Description of testing done
-------------
```

Booted up a cluster containing a utility instance called 'cron', uncommented `require_recipe "cron"` from the main cookbook recipe, upload and applied then verified that the two test crons were installed.

```
QA Instructions
-------------
```

1) Boot up a cluster containing a utility instance called 'cron'
2) In cookbooks/main/recipes/default.rb, remove the comment from line 54
3) Upload/apply cookbooks to cluster
4) SSH into utility instance named cron and run 'crontab -e -u deploy'.  You should see two crons that echo test1 and test2
