### PR TITLE
Add monit_disable recipe for CC-509

### DIFF
--- a/cookbooks/monit_disable/README.md
+++ b/cookbooks/monit_disable/README.md
@@ -1,0 +1,18 @@
+monit_disable
+=======================================
+
+This recipe allows you to disable monit services that have been installed by default in your Engine Yard Cloud instances. The monit entry will be stopped and unmonitored, and then the monitrc file will be removed.
+
+To specify the monit services to be disabled, edit the ```services_to_disable``` variable in recipes/default.rb file in this recipe:
+
+```
+services_to_disable = [
+  {:name => "memcache_11211", :monit_file => "memcached"},
+  {:name => "redis"}
+]
+```
+
+If the monit file (the file in /etc/monit.d/) is different from the service name then you need to specify both. Otherwise, you can specify just the service name and the recipe will assume that that is also the monit filename.
+
+
+

--- a/cookbooks/monit_disable/recipes/default.rb
+++ b/cookbooks/monit_disable/recipes/default.rb
@@ -1,0 +1,36 @@
+services_to_disable = [
+  {:name => "memcache_11211", :monit_file => "memcached"},
+  {:name => "redis"}
+]
+
+services_to_disable.each do |svc|
+  service_name = svc[:name]
+  monit_file = svc[:monit_file] || svc[:name]
+  monit_file_absolute_path = "/etc/monit.d/#{monit_file}.monitrc"
+
+  ey_cloud_report "monit-disable" do
+    message "Stopping and unmonitoring #{service_name}"
+  end
+
+  execute "stop #{service_name}" do
+    command "monit stop #{service_name}"
+    ignore_failure true
+    only_if {::File.exists? monit_file_absolute_path}
+  end
+
+  execute "add a keep file" do
+    command "touch /etc/monit.d/keep.#{monit_file}.monitrc"
+    ignore_failure true
+  end
+
+  execute "monit reload" do
+    action :nothing
+  end
+
+  file monit_file_absolute_path do
+    action :delete
+    only_if {::File.exists? monit_file_absolute_path}
+    notifies :run, resources(:execute => "monit reload")
+  end
+
+end


### PR DESCRIPTION
This is a new recipe for disabling unwanted services that we install on instances by default (e.g. memcached, redis)