### PR TITLE
[CC-675] Logrotate explicit about config permissions

### DIFF
--- a/cookbooks/logrotate/recipes/default.rb
+++ b/cookbooks/logrotate/recipes/default.rb
@@ -7,7 +7,7 @@ remote_file "/etc/logrotate.d/nginx" do
   source "nginx.logrotate"
   owner "root"
   group "root"
-  mode "0655"
+  mode "0644"
   backup 0
 end
 


### PR DESCRIPTION
## Description of your patch

Fix permissions in sample recipe
## Recommended Release Notes

Fixed permissions issue in Logrotate recipe
## Estimated risk

low
## Components involved

logrotate
## Description of testing done
## QA Instructions

Before patch

```
ip-10-231-139-12 nginx # logrotate -dv /etc/logrotate.conf
reading config file /etc/logrotate.conf
including /etc/logrotate.d
Ignoring application-logs because of bad file mode.
reading config file collectd
reading config file elog-save-summary
reading config file ey-monitor
extension is now gz
reading config file mysql
Ignoring nginx because of bad file mode.
reading config file openrc
reading config file rsyncd
```

Notice the "Ignoring NAME because of bad file mode."
After the patch, run the command again
these should become

```
 reading config file NAME
```
