### PR TITLE
Use /bin/kill to stop sidekiq process instead of sidekickctl.

### DIFF
--- a/cookbooks/sidekiq/files/default/sidekiq
+++ b/cookbooks/sidekiq/files/default/sidekiq
@@ -25,7 +25,8 @@ conf_file="/data/${app_name}/shared/config/${worker_ref}.yml"
 app_user=$(stat -L -c"%U" "${app_root}")
 
 sidekiq="${app_root}/ey_bundler_binstubs/sidekiq"
-sidekiqctl="${app_root}/ey_bundler_binstubs/sidekiqctl"
+cmd_kill="/bin/kill"
+cmd_cat="/bin/cat"
 
 export HOME="/home/${app_user}"
 
@@ -62,8 +63,8 @@ start ()
 # stop sidekiq
 stop ()
 {
-  # stop using sidekiqctl
-  sudo -u "${app_user}" -H "${sidekiqctl}" stop "${pid_file}"
+  # stop using kill
+  sudo -u "${app_user}" -H "${cmd_kill}" -s TERM `${cmd_cat} ${pid_file}`
   exit $?
 }
 


### PR DESCRIPTION
The example monitrc in the Sidekiq repository stops the process using kill, not sidekiqctl. I was having issues on my own EngineYard servers with monit spawning new Sidekiq processes a short time after killing them after a deploy with standard monit calls in deploy hooks. This lead to multiple Sidekiq instances running at once. This change fixed that in my recipes.
