### PR TITLE
Use the latest dev-java/sun-jdk version

### DIFF
--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -35,7 +35,7 @@ if ['util'].include?(node[:instance_role])
   #
   Chef::Log.info "Updating Sun JDK"
   package "dev-java/sun-jdk" do
-    version "1.6.0.26"
+    version "1.6.0.37"
     action :upgrade
   end
 


### PR DESCRIPTION
dev-java/sun-jdk version 1.6.0.26 is no longer available on Gentoo 12.11.

The available version on Gentoo 12.11 are
1.6.0.35
1.6.0.35-r1
1.6.0.37
