### PR TITLE
Add the pg_stat_statements extension to shared_preload_libraries

### DIFF
--- a/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
@@ -6,4 +6,6 @@ define :postgresql9_pg_stat_statements do
     extname "pg_stat_statements"
     minimum_version 9.2
   end
+
+  include_recipe "postgresql9_extensions::ext_pg_stat_statements"
 end

--- a/cookbooks/postgresql9_extensions/recipes/ext_pg_stat_statements.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_pg_stat_statements.rb
@@ -1,0 +1,22 @@
+directory = "#{@node[:postgres_root]}#{@node[:postgres_version]}"
+
+execute "append to custom.conf" do
+  command %Q{echo "include \'#{directory}/custom_pg_stat_statements.conf\'" >> #{directory}/custom.conf}
+  not_if { File.exists?("#{directory}/custom_pg_stat_statements.conf") }
+end
+
+template "#{@node[:postgres_root]}#{@node[:postgres_version]}/custom_pg_stat_statements.conf" do
+  source "custom_pg_stat_statements.erb"
+  owner "postgres"
+  group "root"
+  mode 0600
+  backup 0
+  variables({
+    :db_version => @node[:postgres_version],
+    :shared_preload_libraries => "'pg_stat_statements'"
+  })
+end
+
+execute "restarting postgres service" do
+  command "/etc/init.d/postgresql-#{@node[:postgres_version]} reload"
+end

--- a/cookbooks/postgresql9_extensions/templates/default/custom_pg_stat_statements.erb
+++ b/cookbooks/postgresql9_extensions/templates/default/custom_pg_stat_statements.erb
@@ -1,0 +1,11 @@
+# ------------------------------------
+# PostgreSQL Custom configuration file
+# DB Version: <%= @db_version  %>
+# ------------------------------------
+#
+# This file was created by the postgresql9_extensions custom chef run
+# the pg_stats_statements extension and consists of lines of the form:
+#
+shared_preload_libraries = <%= @shared_preload_libraries %>
+pg_stat_statements.max = 10000
+pg_stat_statements.track = all


### PR DESCRIPTION
Create a `custom_pg_stat_statements.conf` with the following data:

```
shared_preload_libraries = <%= @shared_preload_libraries %>
pg_stat_statements.max = 10000
pg_stat_statements.track = all
```
