### PR TITLE
changed deprecated code in readme to current implementation

### DIFF
--- a/cookbooks/thinking-sphinx-3/README.md
+++ b/cookbooks/thinking-sphinx-3/README.md
@@ -27,7 +27,7 @@ You will also need to add a deploy hook to restart Sphinx on deploy. Create a fi
 
 ```
 on_app_servers_and_utilities do
-  run "[[ -d #{shared_path}/sphinx ]] && ln -nfs #{shared_path}/sphinx #{current_path}/db/sphinx"
-  run "cd #{current_path} && RAILS_ENV=#{environment} bundle exec rake ts:configure"
+  run "[[ -d #{config.shared_path}/sphinx ]] && ln -nfs #{config.shared_path}/sphinx #{config.current_path}/db/sphinx"
+  run "cd #{config.current_path} && RAILS_ENV=#{config.environment} bundle exec rake ts:configure"
 end
 ```


### PR DESCRIPTION
I received a message that `shared_path`, `current_path`, and `environment` were all deprecated in favor of `config.shared_path`, `config.current_path`,  and `config.environment`. I made changes in the README to use the preferred methods.