### PR TITLE
Add deny-directories recipe

### DIFF
--- a/cookbooks/deny-directories/files/default/custom.conf
+++ b/cookbooks/deny-directories/files/default/custom.conf
@@ -1,0 +1,16 @@
+location /config {
+  deny all;
+  return 404;
+}
+location /log {
+  deny all;
+  return 404;
+}
+location ^~ /.git {
+  deny all;
+  return 404;
+}
+location ~* ^.*\.yml$ {
+  deny all;
+  return 404;
+}

--- a/cookbooks/deny-directories/recipes/default.rb
+++ b/cookbooks/deny-directories/recipes/default.rb
@@ -1,0 +1,14 @@
+if ['app_master', 'app', 'solo'].include?(node[:instance_role])
+	node[:applications].each do |app, data|
+		remote_file "/data/nginx/servers/#{app}/custom.conf" do
+			source "custom.conf"
+			owner node[:owner_name]
+			group node[:owner_name]
+			mode 0644
+		end
+	end
+
+	execute "Reload nginx config" do
+		command "sudo /etc/init.d/nginx reload"
+	end
+end

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -4,6 +4,9 @@
 #  }
 #end
 
+# uncomment to deny access to /log, /config, and .git directories as well as any .yml files
+# include_recipe "deny-directories"
+
 # uncomment to turn on thinking sphinx 2/ultra sphinx. Remember to edit cookbooks/sphinx/recipes/default.rb first!
 # include_recipe "sphinx"
 


### PR DESCRIPTION
Allows for easily excluding directories via nginx custom config, particularly useful for PHP applications on EY
