### PR TITLE
[CC-716] Update the elasticsearch recipe to use Java 7 and Elasticsearch 1.4.0

### DIFF
--- a/cookbooks/elasticsearch/README.md
+++ b/cookbooks/elasticsearch/README.md
@@ -9,35 +9,33 @@ So, we build a web site or an application and want to add search to it, and then
 
 [elasticsearch][2] aims to solve all these problems and more. It is an Open Source (Apache 2), Distributed, RESTful, Search Engine built on top of [Lucene][1].
 
+NOTE: This recipe installs Elasticsearch 1.4 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3120
+
 Dependencies
 --------
 
-  * Your application should use gems(s) such as [tire][5],[rubberband][3],[elastic_searchable][6] or lastly for JRuby users there is [jruby-elasticsearch][4].
+  * Your application should use gems(s) such as [tire][4],[rubberband][3],[elastic_searchable][5].
 
 Using it
 --------
 
-  * There is two ways to run this recipe.  By default you can use the 'default' recipe and use this in an clustered configuration that requires utility instances.  Alternatively you can use the alternate recipe called 'non_util' which will configure your app_master/solo instance to have elasticsearch.  You would add to main/recipes/default.rb the following,
+There are several ways to use this recipe, depending on your environment.
 
-``include_recipe "elasticsearch::non_util"``  
+  1. On a solo environment
 
-  * Otheriwse you would do the following
+``include_recipe "elasticsearch::non_util"``
 
-``include_recipe "elasticsearch"``  
+  2. On a small cluster: run Elasticsearch on app_master
 
-  * Now you should upload the recipes to your environment,
-  
-``ey recipes upload -e <environment>`` 
+  ``include_recipe "elasticsearch::non_util"``
 
-  * If you picked the non_util recipe you can ignore naming your utility instances.  Upload the recipe, click apply and you should find the neccesary things done;otherwise name your utility instances like below.
-  
-  * Add an utility instance with the following naming scheme(s)
-      * elasticsearch_0
-      * elasticsearch_1
-      * elasticsearch_2
-      * ...
+  3. On a cluster with dedicated util instances for Elasticsearch
 
-  * Produce /data/#{appname}/shared/config/elasticsearch.yml on all instances so you can easily parse/configure elasticsearch for your usage.
+  ``include_recipe "elasticsearch"``
+
+  Name the Elasticsearch instances elasticsearch_0, elasticsearch_1, etc.
+
+In all cases, make sure you create `/data/#{appname}/shared/config/elasticsearch.yml` on all application and utility instances so that the application knows how to connect to your elasticsearch server(s).
 
 
 Verify
@@ -49,16 +47,21 @@ On your instance, run:
 
 Results should be simlar to:
 
-    {
-      "ok" : true,
-      "name" : "Charles Xavier",
-      "version" : {
-        "number" : "0.18.2",
-        "snapshot_build" : false
-      },
-      "tagline" : "You Know, for Search"
-     ...
-    }
+```
+{
+  "status" : 200,
+  "name" : "Man-Thing",
+  "cluster_name" : "YourEnvironmentName",
+  "version" : {
+    "number" : "1.4.0",
+    "build_hash" : "bc94bd81298f81c656893ab1ddddd30a99356066",
+    "build_timestamp" : "2014-11-05T14:26:12Z",
+    "build_snapshot" : false,
+    "lucene_version" : "4.10.2"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
 
 Plugins
 --------
@@ -79,7 +82,7 @@ Examples:
 Caveats
 --------
 
-plugin support is still not complete/automated.  CouchDB and Memcached plugins may be worth investigtating, pull requests to improve this.
+plugin support is still not complete/automated.  CouchDB and Memcached plugins may be worth investigating, pull requests to improve this.
 
 Backups
 --------
@@ -96,6 +99,5 @@ issue and submit a pull request.
 [1]: http://lucene.apache.org/
 [2]: http://www.elasticsearch.org/
 [3]: https://github.com/grantr/rubberband
-[4]: https://github.com/jordansissel/jruby-elasticsearch/
-[5]: https://github.com/karmi/tire
-[6]: https://github.com/wireframe/elastic_searchable/
+[4]: https://github.com/karmi/tire
+[5]: https://github.com/wireframe/elastic_searchable/

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -1,5 +1,5 @@
-default[:elasticsearch_version] = "0.18.2"
-default[:elasticsearch_checksum] = "ce1bad39c66b2eb1ec0286aa4c75a03e6d7ac076"
+default[:elasticsearch_version] = "1.4.0"
+default[:elasticsearch_checksum] = "ffba14b85e4f03f9fbcfb86dc65c4a83390514d1"
 default[:elasticsearch_clustername] = "#{node[:environment][:name]}"
 default[:elasticsearch_home] = "/data/elasticsearch"
 default[:elasticsearch_s3_gateway_bucket] = "elasticsearch_#{node[:environment][:name]}"
@@ -7,3 +7,7 @@ default[:elasticsearch_heap_size] = 1000
 default[:elasticsearch_fdulimit] = nil #  nofiles limit make this something like 32768, see /etc/security/limits.conf
 default[:elasticsearch_defaultreplicas] = 1 # replicas are in addition to the original, so 1 replica means 2 copies of each shard
 default[:elasticsearch_defaultshards] = 6 # 6*2 shards per index distributes evenly across 3, 4, or 6 nodes
+
+default[:elastic_search_java_package_name] = "dev-java/icedtea-bin"
+default[:elasticsearch_java_version] = "7.2.3.3-r1"
+default[:elasticsearch_java_eselect_version] = "icedtea-bin-7"

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -18,137 +18,150 @@ if ['util'].include?(node[:instance_role])
     end
   end
 
-  Chef::Log.info "Downloading Elasticsearch v#{node[:elasticsearch_version]} checksum #{node[:elasticsearch_checksum]}"
-  remote_file "/tmp/elasticsearch-#{node[:elasticsearch_version]}.zip" do
-    source "http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{node[:elasticsearch_version]}.zip"
-    mode "0644"
-    checksum node[:elasticsearch_checksum]
-    not_if { File.exists?("/tmp/elasticsearch-#{node[:elasticsearch_version]}.zip") }
-  end
+  if node['name'].include?("elasticsearch_")
+    Chef::Log.info "Downloading Elasticsearch v#{node[:elasticsearch_version]} checksum #{node[:elasticsearch_checksum]}"
+    remote_file "/tmp/elasticsearch-#{node[:elasticsearch_version]}.zip" do
+      source "http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{node[:elasticsearch_version]}.zip"
+      mode "0644"
+      checksum node[:elasticsearch_checksum]
+      not_if { File.exists?("/tmp/elasticsearch-#{node[:elasticsearch_version]}.zip") }
+    end
 
-  user "elasticsearch" do
-    uid 61021
-    gid "nogroup"
-  end
+    user "elasticsearch" do
+      uid 61021
+      gid "nogroup"
+    end
 
-  # Update JAVA as the Java on the AMI can sometimes crash
-  #
-  Chef::Log.info "Updating Sun JDK"
-  package "dev-java/sun-jdk" do
-    version "1.6.0.26"
-    action :upgrade
-  end
+    # Update JAVA as the Java on the AMI can sometimes crash
+    #
+    Chef::Log.info "Updating Java JDK"
+    enable_package node[:elastic_search_java_package_name] do
+      version node[:elasticsearch_java_version]
+      unmask true
+    end
 
-  directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}" do
-    owner "root"
-    group "root"
-    mode 0755
-  end
+    package node[:elastic_search_java_package_name] do
+      version node[:elasticsearch_java_version]
+      action :upgrade
+    end
 
-  ["/var/log/elasticsearch", "/var/lib/elasticsearch", "/var/run/elasticsearch"].each do |dir|
-    directory dir do
+    execute "Set the default Java version to #{node[:elasticsearch_java_version]}" do
+      command "eselect java-vm set system #{node[:elasticsearch_java_eselect_version]}"
+      action :run
+    end
+
+    directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}" do
       owner "root"
       group "root"
       mode 0755
     end
-  end
 
-  bash "unzip elasticsearch" do
-    user "root"
-    cwd "/tmp"
-    code %(unzip /tmp/elasticsearch-#{node[:elasticsearch_version]}.zip)
-    not_if { File.exists? "/tmp/elasticsearch-#{node[:elasticsearch_version]}" }
-  end
+    ["/var/log/elasticsearch", "/var/lib/elasticsearch", "/var/run/elasticsearch"].each do |dir|
+      directory dir do
+        owner "root"
+        group "root"
+        mode 0755
+      end
+    end
 
-  bash "copy elasticsearch root" do
-    user "root"
-    cwd "/tmp"
-    code %(cp -r /tmp/elasticsearch-#{node[:elasticsearch_version]}/* /usr/lib/elasticsearch-#{node[:elasticsearch_version]})
-    not_if { File.exists? "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/lib" }
-  end
+    bash "unzip elasticsearch" do
+      user "root"
+      cwd "/tmp"
+      code %(unzip /tmp/elasticsearch-#{node[:elasticsearch_version]}.zip)
+      not_if { File.exists? "/tmp/elasticsearch-#{node[:elasticsearch_version]}" }
+    end
 
-  directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/plugins" do
-    owner "root"
-    group "root"
-    mode 0755
-  end
+    bash "copy elasticsearch root" do
+      user "root"
+      cwd "/tmp"
+      code %(cp -r /tmp/elasticsearch-#{node[:elasticsearch_version]}/* /usr/lib/elasticsearch-#{node[:elasticsearch_version]})
+      not_if { File.exists? "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/lib" }
+    end
 
-  link "/usr/lib/elasticsearch" do
-    to "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}"
-  end
+    directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/plugins" do
+      owner "root"
+      group "root"
+      mode 0755
+    end
 
-  directory "#{node[:elasticsearch_home]}" do
-    owner "elasticsearch"
-    group "nogroup"
-    mode 0755
-  end
+    link "/usr/lib/elasticsearch" do
+      to "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}"
+    end
 
-  directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/data" do
-    owner "root"
-    group "root"
-    mode 0755
-    action :create
-    recursive true
-  end
+    directory "#{node[:elasticsearch_home]}" do
+      owner "elasticsearch"
+      group "nogroup"
+      mode 0755
+    end
 
-  mount "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/data" do
-    device "#{node[:elasticsearch_home]}"
-    fstype "none"
-    options "bind,rw"
-    action :mount
-  end
+    directory "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/data" do
+      owner "root"
+      group "root"
+      mode 0755
+      action :create
+      recursive true
+    end
 
-  template "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/config/logging.yml" do
-    source "logging.yml.erb"
-    mode 0644
-  end
+    mount "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/data" do
+      device "#{node[:elasticsearch_home]}"
+      fstype "none"
+      options "bind,rw"
+      action :mount
+    end
 
-  directory "/usr/share/elasticsearch" do
-    group "elasticsearch"
-    group "nogroup"
-    mode 0755
-  end
+    template "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/config/logging.yml" do
+      source "logging.yml.erb"
+      mode 0644
+    end
 
-  max_mem = ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m"
-  template "/usr/share/elasticsearch/elasticsearch.in.sh" do
-    source "elasticsearch.in.sh.erb"
-    mode 0644
-    backup 0
-    variables(
-      :es_max_mem => ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m"
-    )
-  end
+    directory "/usr/share/elasticsearch" do
+      group "elasticsearch"
+      group "nogroup"
+      mode 0755
+    end
 
-  # include_recipe "elasticsearch::s3_bucket"
-  template "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/config/elasticsearch.yml" do
-    source "elasticsearch.yml.erb"
-    owner "elasticsearch"
-    group "nogroup"
-    variables(
-      :aws_access_key => node[:aws_secret_key],
-      :aws_access_id => node[:aws_secret_id],
-      :elasticsearch_s3_gateway_bucket => node[:elasticsearch_s3_gateway_bucket],
-      :elasticsearch_instances => elasticsearch_instances.join('", "'),
-      :elasticsearch_defaultreplicas => node[:elasticsearch_defaultreplicas],
-      :elasticsearch_expected => elasticsearch_expected,
-      :elasticsearch_defaultshards => node[:elasticsearch_defaultshards],
-      :elasticsearch_clustername => node[:elasticsearch_clustername]
-    )
-    mode 0600
-    backup 0
-  end
+    max_mem = ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m"
+    template "/usr/share/elasticsearch/elasticsearch.in.sh" do
+      source "elasticsearch.in.sh.erb"
+      mode 0644
+      backup 0
+      variables(
+        :elasticsearch_version => node[:elasticsearch_version],
+        :es_max_mem => ((node[:memory][:total].to_i / 1024 * 0.75)).to_i.to_s + "m"
+      )
+    end
 
-  template "/etc/monit.d/elasticsearch_#{node[:elasticsearch_clustername]}.monitrc" do
-    source "elasticsearch.monitrc.erb"
-    owner "elasticsearch"
-    group "nogroup"
-    backup 0
-    mode 0644
-  end
+    # include_recipe "elasticsearch::s3_bucket"
+    template "/usr/lib/elasticsearch-#{node[:elasticsearch_version]}/config/elasticsearch.yml" do
+      source "elasticsearch.yml.erb"
+      owner "elasticsearch"
+      group "nogroup"
+      variables(
+        :aws_access_key => node[:aws_secret_key],
+        :aws_access_id => node[:aws_secret_id],
+        :elasticsearch_s3_gateway_bucket => node[:elasticsearch_s3_gateway_bucket],
+        :elasticsearch_instances => elasticsearch_instances.join('", "'),
+        :elasticsearch_defaultreplicas => node[:elasticsearch_defaultreplicas],
+        :elasticsearch_expected => elasticsearch_expected,
+        :elasticsearch_defaultshards => node[:elasticsearch_defaultshards],
+        :elasticsearch_clustername => node[:elasticsearch_clustername]
+      )
+      mode 0600
+      backup 0
+    end
 
-  # Tell monit to just reload, if elasticsearch is not running start it.  If it is monit will do nothing.
-  execute "monit reload" do
-    command "monit reload"
+    template "/etc/monit.d/elasticsearch_#{node[:elasticsearch_clustername]}.monitrc" do
+      source "elasticsearch.monitrc.erb"
+      owner "elasticsearch"
+      group "nogroup"
+      backup 0
+      mode 0644
+    end
+
+    # Tell monit to just reload, if elasticsearch is not running start it.  If it is monit will do nothing.
+    execute "monit reload" do
+      command "monit reload"
+    end
   end
 end
 

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
@@ -1,4 +1,4 @@
-ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/elasticsearch-0.16.3.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
+ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/elasticsearch-<%= @elasticsearch_version %>.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
 
 if [ "x$ES_MIN_MEM" = "x" ]; then
     ES_MIN_MEM=256m
@@ -15,7 +15,9 @@ JAVA_OPTS="$JAVA_OPTS -Xms${ES_MIN_MEM}"
 JAVA_OPTS="$JAVA_OPTS -Xmx${ES_MAX_MEM}"
 
 # reduce the per-thread stack size
-JAVA_OPTS="$JAVA_OPTS -Xss128k"
+# 256k is the minimum stack size for newer versions of Elasticsearch
+# see https://groups.google.com/forum/#!topic/elasticsearch/cfihFvFg08Q
+JAVA_OPTS="$JAVA_OPTS -Xss256k"
 
 JAVA_OPTS="$JAVA_OPTS -Djline.enabled=true"
 


### PR DESCRIPTION
NOTE: This recipe installs Elasticsearch 1.4 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3120

Summary of changes

* Load the Java package name and version to install from attributes so that it’s easier to modify later
* Default Java is dev-java/icedtea-bin version 7.2.3.3-r1
* Run eselect after installing Java to ensure that the correct JDK is set
* Increase Java stack size when running Elasticsearch to 256k (needed by newer version of Elasticsearch, see * https://groups.google.com/forum/#!topic/elasticsearch/cfihFvFg08Q)
* Skip the recipe when there are no instances named elasticsearch_x (for default recipe)
* Remove references to JRuby in README.md

The current version of the recipe installs Elasticsearch on _all_ util instances, which is a bug and is inconsistent with README.md. I have updated README.md to make it clearer that the ways to use this recipe are:

(1) on a solo environment - use include_recipe elasticsearch::non_util
(2) on a small cluster with light load or overpowered app_master, run on app_master - use include_recipe elasticsearch::non_util
(3) on an ordinary cluster with dedicated util instances for Elasticsearch - use include_recipe elasticsearch. Name the elasticsearch instances elasticsearch_0, elasticsearch_1, etc.

Tests done
- include_recipe “elasticsearch” on a cluster with 3 util instances named elasticsearch_0, elasticsearch_1 and nonelasticsearch. Elasticsearch should be installed on elasticsearch_0 and _1, and not on the other instances
- include_recipe “elasticsearch::non_util” on a cluster - app_master should have ES running after the chef run
- include_recipe “elasticsearch::non_util” on a solo - instance should have ES running after the chef run