### PR TITLE
[Support-753] Fix Rakefile for Windows users

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'fileutils'
 TOPDIR = File.dirname(__FILE__)
 
 desc "Test your cookbooks for syntax errors"
@@ -22,13 +23,16 @@ end
 
 def create_cookbook(dir)
   raise "Must provide a COOKBOOK=" unless ENV["COOKBOOK"]
+  puts "Detected Windows Platform.  Please remember to save files with Unix style EOL's if needed -- https://help.github.com/articles/dealing-with-line-endings/" if Gem.win_platform?
   puts "** Creating cookbook #{ENV["COOKBOOK"]}"
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "attributes")}" 
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "recipes")}" 
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "definitions")}" 
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "libraries")}" 
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "files", "default")}" 
-  sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "templates", "default")}" 
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "attributes")}"
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "recipes")}"
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "definitions")}"
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "libraries")}"
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "files", "default")}"
+  FileUtils.mkdir_p "#{File.join(dir, ENV["COOKBOOK"], "templates", "default")}"
+  puts "** Created Directories"
+
   unless File.exists?(File.join(dir, ENV["COOKBOOK"], "recipes", "default.rb"))
     open(File.join(dir, ENV["COOKBOOK"], "recipes", "default.rb"), "w") do |file|
       file.puts <<-EOH


### PR DESCRIPTION
Description of your patch
-------------
Fix Rakefile for Windows users

Recommended Release Notes
-------------
Minor fix for Windows users

Estimated risk
-------------
Low

Components involved
-------------
Rakefile

Description of testing done
-------------
`rake new_cookbook COOKBOOK=test_recipe` on OS X, Linux and Windows.

QA Instructions
-------------
Locate a Windows computer or VM
Install Ruby on it (http://railsinstaller.org/en has an installer that includes Git)
Clone ey-cloud-recipes locally
run `rake new_cookbook COOKBOOK=test_recipe` 
Verify it completes successfully (previously complained ` /p is not a valid flag`) 