### PR TITLE
correct the header to jenkins and upgrade jetty's version

### DIFF
--- a/cookbooks/jenkins/files/default/nginx.jetty.conf
+++ b/cookbooks/jenkins/files/default/nginx.jetty.conf
@@ -3,8 +3,10 @@ server {
   server_name _;
   
   location / {
-    proxy_redirect off;
-    proxy_set_header  X-Real-IP  $remote_addr;
-    proxy_pass http://localhost:8080;
-  }
+      proxy_redirect off;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass              http://localhost:8080;
+    }
 }

--- a/cookbooks/jenkins/recipes/default.rb
+++ b/cookbooks/jenkins/recipes/default.rb
@@ -23,6 +23,12 @@ if "solo" == @node[:instance_role] then
   remote_file "/etc/nginx/servers/jetty.conf" do
     source "nginx.jetty.conf"
   end 
+
+  execute "Restart nginx" do
+    command %Q{
+     /etc/init.d/nginx restart
+    }
+  end
 end
 
 if @node[:instance_role] == 'util' then

--- a/cookbooks/jenkins/recipes/jetty_install.rb
+++ b/cookbooks/jenkins/recipes/jetty_install.rb
@@ -1,5 +1,5 @@
 remote_file "/tmp/jetty.tar.gz" do
-  source "jetty-distribution-8.1.11.v20130520.tar.gz"
+  source "http://download.eclipse.org/jetty/stable-8/dist/jetty-distribution-8.1.16.v20140903.tar.gz"
   action :create_if_missing
   mode 0644
 end
@@ -11,12 +11,12 @@ remote_file "/etc/monit.d/jetty.monitrc" do
 end
 
 execute "Install Jetty" do
-  command "tar -zxvf /tmp/jetty.tar.gz jetty-distribution-8.1.11.v20130520/"
+  command "tar -zxvf /tmp/jetty.tar.gz jetty-distribution-8.1.16.v20140903/"
   cwd "/data/"
 end
 
 execute "symlink Jetty" do
-  command "sudo ln -fs /data/jetty-distribution-8.1.11.v20130520 /opt/jetty"
+  command "sudo ln -fs /data/jetty-distribution-8.1.16.v20140903 /opt/jetty"
 end
 
 execute "symlink initscript" do


### PR DESCRIPTION
## Description of your patch

- fixing the jenkins link issues
- upgrade jetty to last stable version


## Estimated risk

Low

## Components involved

Jetty, Nginx

## Description of testing done

Creating an environment which be installed jenkins, and then access jenkins url and click "Manage Jenkins" and do browser back.

## QA Instructions

- To create an environment and upload and apply the recipes with including "jenkins recipe"
https://github.com/engineyard/ey-cloud-recipes/blob/master/cookbooks/jenkins/README.md
