### PR TITLE
Fix Sidekiq cleanup

### DIFF
--- a/cookbooks/sidekiq/recipes/cleanup.rb
+++ b/cookbooks/sidekiq/recipes/cleanup.rb
@@ -9,17 +9,17 @@ execute "reload-monit" do
   action :nothing
 end
 
-unless util_or_app_server?(node[:sidekiq][:utility_name]) 
+if util_or_app_server?(node[:sidekiq][:utility_name]) 
   # report to dashboard
   ey_cloud_report "sidekiq" do
     message "Cleaning up sidekiq (if needed)"
   end
-  
+
   if app_server? || util?
     # loop through applications
     node[:applications].each do |app_name, _|
       # monit
-      file "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
+      file "/etc/monit.d/sidekiq_#{app_name}.monitrc" do
         action :delete
         notifies :run, resources(:execute => "reload-monit")
       end
@@ -30,7 +30,7 @@ unless util_or_app_server?(node[:sidekiq][:utility_name])
           action :delete
         end
       end
-    end 
+    end
 
     # bin script
     file "/engineyard/bin/sidekiq" do


### PR DESCRIPTION
Currently when applying the recipes the sidekiq cleanup never runs on actual sidekiq servers because of what I assume is a `if` `unless` mixup.

If we run 2 sidekiq workers by changing the YML file as follows
```yml
  # Number of workers (not threads)
  :workers => 2,
```
And then in the future decrease the worker count - the processes will never be killed resulting in floating workers not monitored by monit and never update to run the up to date code.

This fixes that by making sure that the cleanup code is run correctly.