### PR TITLE
CC-818

### DIFF
--- a/cookbooks/elasticsearch/README.md
+++ b/cookbooks/elasticsearch/README.md
@@ -9,7 +9,7 @@ So, we build a web site or an application and want to add search to it, and then
 
 [elasticsearch][2] aims to solve all these problems and more. It is an Open Source (Apache 2), Distributed, RESTful, Search Engine built on top of [Lucene][1].
 
-NOTE: This recipe installs Elasticsearch 1.4 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3120
+NOTE: This recipe installs Elasticsearch 1.4.4 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3120
 
 Dependencies
 --------

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -1,5 +1,5 @@
-default[:elasticsearch_version] = "1.4.0"
-default[:elasticsearch_checksum] = "ffba14b85e4f03f9fbcfb86dc65c4a83390514d1"
+default[:elasticsearch_version] = "1.4.4"
+default[:elasticsearch_checksum] = "52f40875c7bf5b93252017ce2cd0f779ca2c51fd"
 default[:elasticsearch_clustername] = "#{node[:environment][:name]}"
 default[:elasticsearch_home] = "/data/elasticsearch"
 default[:elasticsearch_s3_gateway_bucket] = "elasticsearch_#{node[:environment][:name]}"

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -97,6 +97,9 @@
 #uncomment to include the Elasticsearch recipe
 #include_recipe "elasticsearch"
 
+#uncomment to include the Elasticsearch recipe on solos and app masters
+#include_recipe "elasticsearch::non_util"
+
 # To install specific plugins to Elasticsearch see below as an example
 #es_plugin "cloud-aws" do
 #  action :install


### PR DESCRIPTION
NOTE: This recipe installs Elasticsearch 1.4.4 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.4.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1427

Summary of changes

Updated installed version to ElasticSearch 1.4.4
Updated default.rb in main to have nonutil an uncommented option

Tests done

include_recipe “elasticsearch” on a cluster with a util instance named elasticsearch_0 verified elastic search runs properly with the new version

include_recipe “elasticsearch::non_util” on a solo - instance should have ES running after the chef run verified elastic search runs properly with the new version