### PR TITLE
Chef '@node' calls deprecated in favor of 'node'

### DIFF
--- a/cookbooks/jenkins/recipes/default.rb
+++ b/cookbooks/jenkins/recipes/default.rb
@@ -1,10 +1,10 @@
 
-if ['app_master','solo'].include? @node[:instance_role] then
+if ['app_master','solo'].include? node[:instance_role] then
   include_recipe "jenkins::jetty_install"
   include_recipe "jenkins::jenkins_install"
 end
 
-if "app_master" == @node[:instance_role] then
+if "app_master" == node[:instance_role] then
   execute "touch /etc/keep.haproxy.cfg" do
     action :run
   end
@@ -12,17 +12,17 @@ if "app_master" == @node[:instance_role] then
     source "haproxy.cfg"
     action :create
   end
-  
+
   execute "Restart HAProxy" do
     command "sudo /etc/init.d/haproxy reload"
   end
-   
+
 end
 
-if "solo" == @node[:instance_role] then
+if "solo" == node[:instance_role] then
   remote_file "/etc/nginx/servers/jetty.conf" do
     source "nginx.jetty.conf"
-  end 
+  end
 
   execute "Restart nginx" do
     command %Q{
@@ -31,6 +31,6 @@ if "solo" == @node[:instance_role] then
   end
 end
 
-if @node[:instance_role] == 'util' then
+if node[:instance_role] == 'util' then
   include_recipe "jenkins::swarm_install"
 end

--- a/cookbooks/memcached/templates/default/memcached.yml.erb
+++ b/cookbooks/memcached/templates/default/memcached.yml.erb
@@ -16,7 +16,7 @@ defaults:
   fast_hash: false
   fastest_hash: false
 
-<%= @node[:environment][:framework_env] %>:
+<%= node[:environment][:framework_env] %>:
   memory: 64
   benchmarking: false
   sessions: false

--- a/cookbooks/mongodb/recipes/app.rb
+++ b/cookbooks/mongodb/recipes/app.rb
@@ -1,14 +1,14 @@
 if node[:utility_instances].empty?
   # no-op here as there are no utility instances, do not pass.
   else
-    user = @node[:users].first
+    user = node[:users].first
 
     if ['app_master','app'].include?(node[:instance_role])
-      mongo_replication_sets = @node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| instance[:name].split("_")[1].sub("repl","") }.uniq   
+      mongo_replication_sets = node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| instance[:name].split("_")[1].sub("repl","") }.uniq
     end
-  mongo_app_names = @node[:applications].keys
+  mongo_app_names = node[:applications].keys
 
-  # Chef::Log.info "app.rb - mongo_replication_sets = #{mongo_replication_sets} | node app keys = #{@node[:applications].keys}"
+  # Chef::Log.info "app.rb - mongo_replication_sets = #{mongo_replication_sets} | node app keys = #{node[:applications].keys}"
 
   mongo_app_names.each do |mongo_app_name|
      # Chef::Log.info "looping for mongo_app_name = #{mongo_app_name}"
@@ -19,13 +19,13 @@ if node[:utility_instances].empty?
       group user[:username]
       mode 0755
 
-      if @node[:instance_role] == "solo" && @node[:mongo_utility_instances].length == 0
+      if node[:instance_role] == "solo" && node[:mongo_utility_instances].length == 0
         variables(:yaml_file => {
           node[:environment][:framework_env] => {
-            :hosts => [ [ "localhost", @node[:mongo_port].to_i ] ] } } )
+            :hosts => [ [ "localhost", node[:mongo_port].to_i ] ] } } )
       else
-        hosts = @node[:mongo_utility_instances].select { |instance| instance[:name].match(/#{mongo_app_name}/) }.map { |instance| [ instance[:hostname], @node[:mongo_port].to_i ] }
-        hosts += @node[:mongo_utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| [ instance[:hostname], @node[:mongo_port].to_i ] }
+        hosts = node[:mongo_utility_instances].select { |instance| instance[:name].match(/#{mongo_app_name}/) }.map { |instance| [ instance[:hostname], node[:mongo_port].to_i ] }
+        hosts += node[:mongo_utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| [ instance[:hostname], node[:mongo_port].to_i ] }
         variables(:yaml_file => {
           node[:environment][:framework_env] => {
             :hosts => hosts} })
@@ -39,12 +39,12 @@ if node[:utility_instances].empty?
       group user[:username]
       mode 0755
 
-      hosts = @node[:mongo_utility_instances].select { |instance| instance[:name].match(/#{mongo_app_name}/) }.map { |instance| [ instance[:hostname], @node[:mongo_port].to_i ] }
-      replica_set = @node[:mongo_utility_instances].any? { |instance| instance[:name].match(/^mongodb_repl/) }
+      hosts = node[:mongo_utility_instances].select { |instance| instance[:name].match(/#{mongo_app_name}/) }.map { |instance| [ instance[:hostname], node[:mongo_port].to_i ] }
+      replica_set = node[:mongo_utility_instances].any? { |instance| instance[:name].match(/^mongodb_repl/) }
       if replica_set
-        hosts += @node[:mongo_utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| [ instance[:hostname], @node[:mongo_port].to_i ] }
+        hosts += node[:mongo_utility_instances].select { |instance| instance[:name].match(/^mongodb_repl/) }.map { |instance| [ instance[:hostname], node[:mongo_port].to_i ] }
       end
-      variables(:environment => node[:environment][:framework_env], 
+      variables(:environment => node[:environment][:framework_env],
                 :hosts => hosts,
                 :replica_set => replica_set,
                 :mongo_replsetname => node[:environment][:name] )

--- a/cookbooks/mongodb/recipes/backup.rb
+++ b/cookbooks/mongodb/recipes/backup.rb
@@ -7,8 +7,8 @@ ey_cloud_report "mongodb" do
   message "configuring backup"
 end
 
-mongo_nodes = @node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl#{@node[:mongo_replset]}/) }
-if @node[:name] == mongo_nodes.last[:name]
+mongo_nodes = node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl#{node[:mongo_replset]}/) }
+if node[:name] == mongo_nodes.last[:name]
 
   node[:applications].each do |app_name, data|
     user = node[:users].first

--- a/cookbooks/mongodb/recipes/configure.rb
+++ b/cookbooks/mongodb/recipes/configure.rb
@@ -1,14 +1,14 @@
-user = @node[:users].first
-mongodb_bin = "#{@node[:mongo_path]}/bin"
+user = node[:users].first
+mongodb_bin = "#{node[:mongo_path]}/bin"
 
-if ['db_master','solo'].include? @node[:instance_role]
+if ['db_master','solo'].include? node[:instance_role]
   #under /mnt because it's an arbiter. No data saved
   mongo_data = "/mnt/mongodb/data"
   mongo_log = "/mnt/mongodb/log"
 else
   #save under /data
-  mongo_data = @node[:mongo_base] + "/data"
-  mongo_log = @node[:mongo_base] + "/log"
+  mongo_data = node[:mongo_base] + "/data"
+  mongo_log = node[:mongo_base] + "/log"
 end
 
 directory mongo_data do
@@ -59,19 +59,19 @@ mongodb_options = { :exec => "#{mongodb_bin}/mongod",
                     :user => user[:username],
                     :pid_path => "/var/run/mongodb",
                     :ip => "0.0.0.0",
-                    :port => @node[:mongo_port],
+                    :port => node[:mongo_port],
                     :extra_opts => '' }
 
-if @node[:mongo_journaling]
+if node[:mongo_journaling]
   mongodb_options[:extra_opts]  << " --journal"
 end
 
-if @node[:mongo_replset]
-  mongodb_options[:extra_opts]  << " --replSet #{@node[:mongo_replset]}"
+if node[:mongo_replset]
+  mongodb_options[:extra_opts]  << " --replSet #{node[:mongo_replset]}"
 end
 
-if @node[:oplog_size]
-  mongodb_options[:extra_opts]  << " --oplogSize=#{@node[:oplog_size]}"
+if node[:oplog_size]
+  mongodb_options[:extra_opts]  << " --oplogSize=#{node[:oplog_size]}"
 end
 
 mongodb_options[:extra_opts]  << " --directoryperdb"

--- a/cookbooks/mongodb/recipes/default.rb
+++ b/cookbooks/mongodb/recipes/default.rb
@@ -3,7 +3,7 @@
 # Recipe:: default
 #
 # Save credentials on app_master
-if ['app_master','app','solo','util'].include? @node[:instance_role]
+if ['app_master','app','solo','util'].include? node[:instance_role]
   Chef::Log.info "creating app mongo.yml code"
   include_recipe "mongodb::app"
 end
@@ -14,7 +14,7 @@ when "i686"
   # Chef::Log.info "MongoDB cannot be hold data in 32bit systems"
 
 else
-  if (@node[:instance_role] == 'util' && @node[:name].match(/mongodb/)) || (@node[:instance_role] == "solo" &&  @node[:mongo_utility_instances].length == 0)
+  if (node[:instance_role] == 'util' && node[:name].match(/mongodb/)) || (node[:instance_role] == "solo" &&  node[:mongo_utility_instances].length == 0)
     ey_cloud_report "mongodb" do
       message "configuring mongodb"
     end
@@ -24,13 +24,13 @@ else
     include_recipe "mongodb::backup"
     include_recipe "mongodb::start"
 
-    if @node[:mongo_replset]
+    if node[:mongo_replset]
       include_recipe "mongodb::replset"
     end
   end
 
   # Setup an arbiter on the db_master|solo as replica sets need another vote to properly failover.  If you have a Replica set > 3 nodes we don't set this up, you can tune this obviously.
-  if (['db_master','solo'].include?(@node[:instance_role]) &&  @node[:mongo_utility_instances].length == 2)
+  if (['db_master','solo'].include?(node[:instance_role]) &&  node[:mongo_utility_instances].length == 2)
     Chef::Log.info "Setting up Mongo in db_master or solo"
     include_recipe "mongodb::install"
     include_recipe "mongodb::configure"
@@ -40,7 +40,7 @@ else
 end
 
 #install mms on db_master or solo. This will need to change for db-less environments
-if ['db_master', 'solo'].include? @node[:instance_role]
-  Chef::Log.info "Installing MMS on #{@node[:instance_role]}"
+if ['db_master', 'solo'].include? node[:instance_role]
+  Chef::Log.info "Installing MMS on #{node[:instance_role]}"
   include_recipe "mongodb::install_mms"
 end

--- a/cookbooks/mongodb/recipes/install_mms.rb
+++ b/cookbooks/mongodb/recipes/install_mms.rb
@@ -11,7 +11,7 @@ SECRET_KEYS = {
   "EnvName" => ""
 }
 # setting API_KEYS and SECRET_KEYS for your environment effectively enables this recipe
-if API_KEYS.has_key? @node[:environment][:name] and SECRET_KEYS.has_key? @node[:environment][:name]
+if API_KEYS.has_key? node[:environment][:name] and SECRET_KEYS.has_key? node[:environment][:name]
   InstallDirectory = "/db/mms"
   MmsFileName = "10gen-mms-agent"
   MmsZipFile = "#{MmsFileName}.zip"
@@ -37,7 +37,7 @@ if API_KEYS.has_key? @node[:environment][:name] and SECRET_KEYS.has_key? @node[:
 
   execute "Modify settings.py" do
     cwd "#{InstallDirectory}/mms-agent"
-    command "sed -i 's/@API_KEY@/#{API_KEYS[@node[:environment][:name]]}/g' settings.py && sed -i 's/@SECRET_KEY@/#{SECRET_KEYS[@node[:environment][:name]]}/g' settings.py && sed -i 's/mms-stage/mms/g' settings.py"
+    command "sed -i 's/@API_KEY@/#{API_KEYS[node[:environment][:name]]}/g' settings.py && sed -i 's/@SECRET_KEY@/#{SECRET_KEYS[node[:environment][:name]]}/g' settings.py && sed -i 's/mms-stage/mms/g' settings.py"
   end
 
   remote_file "#{InstallDirectory}/mms.sh" do

--- a/cookbooks/mongodb/recipes/replset.rb
+++ b/cookbooks/mongodb/recipes/replset.rb
@@ -1,13 +1,13 @@
-user = @node[:users].first
+user = node[:users].first
 
 mongo_arbiter="na"
 
-if @node[:mongo_replset]
-  mongo_nodes = @node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl#{@node[:mongo_replset]}/) }
+if node[:mongo_replset]
+  mongo_nodes = node[:utility_instances].select { |instance| instance[:name].match(/^mongodb_repl#{node[:mongo_replset]}/) }
 
-  # Chef::Log.info "Setting up Replica set: #{node[:mongo_replset]} \n mongo_nodes: #{mongo_nodes.inspect} \n executing on node #{@node[:name]}"
+  # Chef::Log.info "Setting up Replica set: #{node[:mongo_replset]} \n mongo_nodes: #{mongo_nodes.inspect} \n executing on node #{node[:name]}"
 
-  if (@node[:name].match(/_1$/) && (mongo_nodes.length == 3 || (mongo_nodes.length ==2 && mongo_arbiter.length > 3)))
+  if (node[:name].match(/_1$/) && (mongo_nodes.length == 3 || (mongo_nodes.length ==2 && mongo_arbiter.length > 3)))
     setup_js = "#{node[:mongo_base]}/setup_replset.js"
 
     template setup_js do
@@ -15,9 +15,9 @@ if @node[:mongo_replset]
       owner user[:username]
       group user[:username]
       mode '0755'
-      variables({ :mongo_replset => @node[:mongo_replset],
+      variables({ :mongo_replset => node[:mongo_replset],
                   :mongo_nodes => mongo_nodes,
-                  :mongo_port => @node[:mongo_port],
+                  :mongo_port => node[:mongo_port],
                   :mongo_arbiter => mongo_arbiter
                })
     end
@@ -25,14 +25,14 @@ if @node[:mongo_replset]
     #----- wait for set members to be up and initialize -----
      mongo_nodes.each do |mongo_node|
       execute "wait for mongo on #{mongo_node[:hostname]} to come up" do
-        command "until echo 'exit' | #{@node[:mongo_path]}/bin/mongo #{mongo_node[:hostname]}:#{@node[:mongo_port]}/local --quiet; do sleep 10s; done"
+        command "until echo 'exit' | #{node[:mongo_path]}/bin/mongo #{mongo_node[:hostname]}:#{node[:mongo_port]}/local --quiet; do sleep 10s; done"
       end
     end
     # ----- configure the set
-    execute "setup replset #{@node[:mongo_replset]}" do
-      command "#{@node[:mongo_path]}/bin/mongo local #{setup_js}"
-      only_if "echo 'rs.status()' | #{@node[:mongo_path]}/bin/mongo local --quiet | grep -q 'run rs.initiate'"
-      Chef::Log.info "Replica set node initialized" 
+    execute "setup replset #{node[:mongo_replset]}" do
+      command "#{node[:mongo_path]}/bin/mongo local #{setup_js}"
+      only_if "echo 'rs.status()' | #{node[:mongo_path]}/bin/mongo local --quiet | grep -q 'run rs.initiate'"
+      Chef::Log.info "Replica set node initialized"
     end
 
   else

--- a/cookbooks/postgresql9_extensions/definitions/load_shared_library.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_shared_library.rb
@@ -2,16 +2,16 @@ define :load_shared_library, :db_name => nil, :library_name => nil, :minimum_ver
   library_name = params[:library_name]
   db_name = params[:db_name]
   minimum_version = params[:minimum_version].to_f
-  
-  Chef::Log.info "Loading to database #{db_name} library #{library_name} supported on versions higher than: #{minimum_version}. PG version installed is #{@node[:postgres_version]}"
-  
+
+  Chef::Log.info "Loading to database #{db_name} library #{library_name} supported on versions higher than: #{minimum_version}. PG version installed is #{node[:postgres_version]}"
+
   # we ensure a minimum version is set, the version selected is at least the minimum version
-  if not minimum_version.nil? && @node[:postgres_version] >= minimum_version
+  if not minimum_version.nil? && node[:postgres_version] >= minimum_version
     # now we ensure the install syntax is appropriate for this version
-    if @node[:postgres_version] == 0.0
+    if node[:postgres_version] == 0.0
       # we skip this
-    # elsif @node[:postgres_version].to_f >= [some future revision where syntax changes]
-    elsif @node[:postgres_version] >= 9.0
+    # elsif node[:postgres_version].to_f >= [some future revision where syntax changes]
+    elsif node[:postgres_version] >= 9.0
       execute "Postgresql loading library #{library_name}" do
         command "psql -U postgres -d #{db_name} -c \"LOAD \'#{library_name}\'\";"
       end

--- a/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
+++ b/cookbooks/postgresql9_extensions/definitions/load_sql_file.rb
@@ -3,20 +3,20 @@ define :load_sql_file, :db_name => nil, :extname => nil, :minimum_version => nil
   extname = params[:extname]
   minimum_version = params[:minimum_version].to_f
 
-  if ['solo','db_master'].include?(@node[:instance_role])
-    Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions higher than: #{minimum_version}. PG version installed is #{@node[:postgres_version]}"
-    
+  if ['solo','db_master'].include?(node[:instance_role])
+    Chef::Log.info "Loading to database #{db_name} extension #{extname} supported on versions higher than: #{minimum_version}. PG version installed is #{node[:postgres_version]}"
+
     # we ensure a minimum version is set, the version selected is at least the minimum version
-    if not minimum_version.nil? && @node[:postgres_version] >= minimum_version
+    if not minimum_version.nil? && node[:postgres_version] >= minimum_version
       # now we ensure the install syntax is appropriate for this version
-      if @node[:postgres_version] == 0.0
+      if node[:postgres_version] == 0.0
         # we skip this
-      # elsif @node[:postgres_version].to_f >= [some future revision where syntax changes]
-      elsif @node[:postgres_version] >= 9.1
+      # elsif node[:postgres_version].to_f >= [some future revision where syntax changes]
+      elsif node[:postgres_version] >= 9.1
         execute "Postgresql loading extension #{extname}" do
           command %Q(psql -U postgres -d #{db_name} -c 'CREATE EXTENSION IF NOT EXISTS "#{extname}";')
         end
-      elsif @node[:postgres_version] >= 9.0
+      elsif node[:postgres_version] >= 9.0
         execute "Postgresql loading contrib #{extname} on database #{db_name}" do
           command "psql -U postgres -d #{db_name} -f /usr/share/postgresql-9.0/contrib/#{extname}.sql"
         end

--- a/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
+++ b/cookbooks/postgresql9_extensions/definitions/pg_stat_statements.rb
@@ -8,7 +8,7 @@ define :postgresql9_pg_stat_statements do
   end
 
   #add shared_preload_libraries and pg_stat_statements to custom pgconf
-  p = "/db/postgresql/#{@node[:postgres_version]}/custom.conf"
+  p = "/db/postgresql/#{node[:postgres_version]}/custom.conf"
   ext_name = "pg_stat_statements"
   update_file "add #{ext_name} to #{p}" do
     action :append

--- a/cookbooks/postgresql9_extensions/definitions/postgis.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis.rb
@@ -1,51 +1,51 @@
 define :postgresql9_postgis do
   dbname_to_use = params[:name]
-  
-  if @node[:postgres_version] >= 9.3
-    Chef::Log.info "Postgis 1.5 is not supported on versions 9.3 and higher; your current version is #{@node[:postgres_version]}. Please use the postgis2 extension instead."
+
+  if node[:postgres_version] >= 9.3
+    Chef::Log.info "Postgis 1.5 is not supported on versions 9.3 and higher; your current version is #{node[:postgres_version]}. Please use the postgis2 extension instead."
   else
     include_recipe "postgresql9_extensions::ext_postgis_install"
-    
-    if ['solo','db_master'].include?(@node[:instance_role])
-      if @node[:postgres_version] == 9.0
-        
+
+    if ['solo','db_master'].include?(node[:instance_role])
+      if node[:postgres_version] == 9.0
+
           load_sql_file do
             db_name dbname_to_use
             minimum_version 9.0
             extname "postgis-1.5/postgis"
           end
-      
+
           load_sql_file do
             db_name dbname_to_use
             minimum_version 9.0
             extname "postgis-1.5/spatial_ref_sys"
           end
-      
+
           load_sql_file do
             db_name dbname_to_use
             minimum_version 9.0
             extname"postgis-1.5/postgis_comments"
           end
-      elsif @node[:postgres_version] >= 9.1
-        pgversion = @node[:postgres_version]
-      
+      elsif node[:postgres_version] >= 9.1
+        pgversion = node[:postgres_version]
+
          execute "Postgresql loading postgis 1.5 on database #{dbname_to_use} for version #{pgversion}" do
            command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis.sql"
          end
-      
+
         execute "Postgresql loading spatial_ref_sys on database #{dbname_to_use} for version #{pgversion}" do
           command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/spatial_ref_sys.sql"
         end
-      
+
         execute "Postgresql loading postgis_comments on database #{dbname_to_use} for version #{pgversion}" do
           command "psql -U postgres -d #{dbname_to_use} -f /usr/share/postgresql-#{pgversion}/contrib/postgis-1.5/postgis_comments.sql"
         end
       end
-      
+
       execute "Grant permissions to the deploy user on the geometry_columns schema" do
         command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on geometry_columns to deploy\""
       end
-      
+
       execute "Grant permissions to the deploy user on the spatial_ref_sys schema" do
         command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on spatial_ref_sys to deploy\""
       end

--- a/cookbooks/postgresql9_extensions/definitions/postgis2.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis2.rb
@@ -1,20 +1,20 @@
 define :postgresql9_postgis2 do
   dbname_to_use = params[:name]
 
-  if @node[:postgres_version] >= 9.2
+  if node[:postgres_version] >= 9.2
     include_recipe "postgresql9_extensions::ext_postgis2_install"
-    
-    if ['solo','db_master'].include?(@node[:instance_role])
+
+    if ['solo','db_master'].include?(node[:instance_role])
       load_sql_file do
         db_name dbname_to_use
         minimum_version 9.2
         extname "postgis"
       end
-      
+
       execute "Grant permissions to the deploy user on the geometry_columns schema" do
         command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on geometry_columns to deploy\""
       end
-      
+
       execute "Grant permissions to the deploy user on the spatial_ref_sys schema" do
         command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on spatial_ref_sys to deploy\""
       end

--- a/cookbooks/postgresql9_extensions/recipes/ext_autoexplain.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_autoexplain.rb
@@ -1,18 +1,18 @@
-directory = "#{@node[:postgres_root]}#{@node[:postgres_version]}"
+directory = "#{node[:postgres_root]}#{node[:postgres_version]}"
 
 execute "append to custom.conf" do
   command %Q{echo "include \'#{directory}/custom_autoexplain.conf\'" >> #{directory}/custom.conf}
   not_if { File.exists?("#{directory}/custom_autoexplain.conf") }
 end
 
-template "#{@node[:postgres_root]}#{@node[:postgres_version]}/custom_autoexplain.conf" do
+template "#{node[:postgres_root]}#{node[:postgres_version]}/custom_autoexplain.conf" do
   source "custom_autoexplain.erb"
   owner "postgres"
   group "root"
   mode 0600
   backup 0
   variables({
-    :db_version => @node[:postgres_version],
+    :db_version => node[:postgres_version],
     :shared_preload_libraries => "'auto_explain'",
     :custom_variable_classes => "'auto_explain'",
     :auto_explain_log_min_duration => "'3s'",
@@ -25,6 +25,6 @@ template "#{@node[:postgres_root]}#{@node[:postgres_version]}/custom_autoexplain
 end
 
 execute "reload postgres service" do
-  command "/etc/init.d/postgresql-#{@node[:postgres_version]} reload"
+  command "/etc/init.d/postgresql-#{node[:postgres_version]} reload"
 end
 

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
@@ -1,4 +1,4 @@
-if @node[:postgres_version] >= 9.2
+if node[:postgres_version] >= 9.2
   postgis_version = "2.1.1"
   proj_version = "4.6.1"
   geos_version = "3.4.2"

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis_install.rb
@@ -1,4 +1,4 @@
-if @node[:postgres_version] == 9.0
+if node[:postgres_version] == 9.0
   postgis_version = "1.5.2"
   proj_version = "4.6.1"
   geos_version = "3.2.2"
@@ -22,7 +22,7 @@ if @node[:postgres_version] == 9.0
     version postgis_version
     action :install
   end
-elsif @node[:postgres_version] >= 9.1
+elsif node[:postgres_version] >= 9.1
   postgis_version = "1.5.8"
   proj_version = "4.6.1"
   geos_version = "3.3.5"
@@ -41,7 +41,7 @@ elsif @node[:postgres_version] >= 9.1
   enable_package "dev-db/postgis" do
     version postgis_version
   end
-  
+
   package "sci-libs/geos" do
     version geos_version
   end

--- a/cookbooks/postgresql_maintenance/recipes/default.rb
+++ b/cookbooks/postgresql_maintenance/recipes/default.rb
@@ -1,6 +1,6 @@
 
 # Sets a default schedule of Midnight system time Sunday for a vacuum
-if @node[:instance_role][/^db_master/]
+if node[:instance_role][/^db_master/]
   cron "manual_vacuumdb" do
     minute  '0'
     hour    '0'
@@ -9,7 +9,7 @@ if @node[:instance_role][/^db_master/]
     weekday '0'
     command '/usr/bin/vacuumdb -U postgres --all'
   end
-  
+
   # Alternative form - vacuums a specific named database and set of tables Midnight on Saturday
   # cron "manual_vacuumdb_#{dbname}" do
   #   minute  '0'

--- a/cookbooks/sphinx/templates/default/sphinx.yml.erb
+++ b/cookbooks/sphinx/templates/default/sphinx.yml.erb
@@ -1,10 +1,10 @@
-<%= @node[:environment][:framework_env] %>:
+<%= node[:environment][:framework_env] %>:
   searchd_log_file: /var/log/engineyard/sphinx/<%= @app_name %>/searchd.log
   query_log_file: /var/log/engineyard/sphinx/<%= @app_name %>/query.log
   pid_file: /var/run/sphinx/<%= @app_name %>.pid
   address: <%= @address %>
   port: 9312
   mem_limit: <%= @mem_limit %>
-  config_file: /data/<%= @app_name %>/current/config/sphinx/<%= @node[:environment][:framework_env] %>.sphinx.conf
+  config_file: /data/<%= @app_name %>/current/config/sphinx/<%= node[:environment][:framework_env] %>.sphinx.conf
   searchd_file_path: /var/log/engineyard/sphinx/<%= @app_name %>/indexes
 


### PR DESCRIPTION
EngineYard custom log is showing too many WARNING entries caused by `@node` calls in EY chef recipes.

Example: 

> [Tue, 08 Jun 2010 12:01:44 -0700] WARN: Accessing node by the variable @node is deprecated. Support will be removed in a future release.
> [Tue, 08 Jun 2010 12:01:44 -0700] WARN: Please update your cookbooks to use node in place of @node. Accessed from: ...

So I did a massive replacement in all our recipes and... It worked fine and got a much cleaner EngineYard custom configuration log. 
I think that is time to get rid of these annoying warning messages and avoid future problems caused by syntax deprecation.
