### PR TITLE
Fix Postgis recipes

### DIFF
--- a/cookbooks/main/libraries/ey_release_version.rb
+++ b/cookbooks/main/libraries/ey_release_version.rb
@@ -1,0 +1,12 @@
+module EY
+  module Helpers
+    def ey_release_version
+      release = File.read('/etc/engineyard/release')
+      return "12.11" if release.to_i > 2009
+      "2009a"
+    end
+  end
+end
+
+Chef::Recipe.send(:include, EY::Helpers)
+Chef::Resource.send(:include, EY::Helpers)

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -143,11 +143,12 @@
   # postgresql9_pgcrypto "dbname"
   # postgresql9_pgrowlocks "dbname"
 
-  # PostGis 1.5 (use with versions 9.0, 9.1, 9.2)
+  # PostGis 1.5 (use with versions 9.0, 9.1, 9.2 on 2009a/stable-v2)
   # postgresql9_postgis "dbname"
 
-  # PostGis 2.0 (use with versions >= 9.2)
-  #postgresql9_postgis2 "dbname"
+  # PostGis 2.1 (use with version 9.2 on 2009a/stable-v2 and all versions on 12.11/stable-v4)
+  # postgresql9_postgis2 "dbname"
+
   # postgresql9_seg "dbname"
   # postgresql9_sslinfo "dbname"
   # postgresql9_tablefunc "dbname"

--- a/cookbooks/postgresql9_extensions/definitions/postgis.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis.rb
@@ -1,8 +1,9 @@
 define :postgresql9_postgis do
   dbname_to_use = params[:name]
   
-  if @node[:postgres_version] >= 9.3
-    Chef::Log.info "Postgis 1.5 is not supported on versions 9.3 and higher; your current version is #{@node[:postgres_version]}. Please use the postgis2 extension instead."
+  if ey_release_version == '1211' or @node[:postgres_version] >= 9.3
+    Chef::Log.info "Postgis 1.5 is not supported on versions 9.3 and higher nor on 12.11/stable-v4 at all; your current version is #{@node[:postgres_version]}/#{ey_release_version}. Please use the postgis2 extension instead."
+    exit(1)
   else
     include_recipe "postgresql9_extensions::ext_postgis_install"
     

--- a/cookbooks/postgresql9_extensions/definitions/postgis2.rb
+++ b/cookbooks/postgresql9_extensions/definitions/postgis2.rb
@@ -1,16 +1,32 @@
 define :postgresql9_postgis2 do
   dbname_to_use = params[:name]
 
+  if @node[:postgres_version] < 9.2 || (ey_release_version == '2009a' and @node[:postgres_version] == 9.2)
+    Chef::Log.info("Postgis 2 is not supported with Postgres <=9.2 on 2009a/stable-v2.  Please, use the Postgis 1.5 extension instead (ext_postgis_install), move to a 12.11/stable-v4 environment, or upgrade to PostgreSQL 9.3.")
+    exit(1)
+  end
+
   if @node[:postgres_version] >= 9.2
     include_recipe "postgresql9_extensions::ext_postgis2_install"
-    
+
+    if ey_release_version == '2009a'
+      postgis_version = "2.1.1"
+    else
+      postgis_version = "2.1.5"
+    end
+
     if ['solo','db_master'].include?(@node[:instance_role])
       load_sql_file do
         db_name dbname_to_use
         minimum_version 9.2
         extname "postgis"
       end
-      
+
+      execute "Updating to correct postgis minor version" do
+        # this is essentially a no-op if already on this version.
+        command %Q{psql -U postgres -d #{dbname_to_use} -c 'ALTER EXTENSION postgis UPDATE TO "#{postgis_version}";'}
+      end
+
       execute "Grant permissions to the deploy user on the geometry_columns schema" do
         command "psql -U postgres -d #{dbname_to_use} -c \"GRANT all on geometry_columns to deploy\""
       end

--- a/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
+++ b/cookbooks/postgresql9_extensions/recipes/ext_postgis2_install.rb
@@ -1,8 +1,19 @@
 if @node[:postgres_version] >= 9.2
-  postgis_version = "2.1.1"
   proj_version = "4.6.1"
   geos_version = "3.4.2"
-  gdal_version = "1.10.0-r1"
+  python_exec_version = "0.2"
+
+  if ey_release_version == '2009a'
+    gdal_version = "1.10.0"
+    postgis_version = "2.1.1-r1"
+
+    enable_package "dev-libs/json-c" do
+      version "0.11"
+    end
+  else
+    gdal_version = "1.10.0-r1"
+    postgis_version = "2.1.5"
+  end
 
   package_use "sci-libs/geos" do
     flags "-ruby"
@@ -23,6 +34,11 @@ if @node[:postgres_version] >= 9.2
     version postgis_version
   end
 
+  enable_package "dev-python/python-exec" do
+    version python_exec_version
+  end
+
+  # normal install case
   package "dev-db/postgis" do
     version postgis_version
     action :install


### PR DESCRIPTION
* postgis 2.1.5 for pg 9.3/9.4 on 12.11
* Add ey_release_version helper method in main cookbook's libraries
* Fix postgis 2.1.1 installs on 9.3/2009a and 9.2/12.11
* Tweaks to abort execution if chosen postgis version isn't supported
  for current Postgres version and/or environment stack