### PR TITLE
Use equality to determine the matching node name

### DIFF
--- a/cookbooks/cron/recipes/default.rb
+++ b/cookbooks/cron/recipes/default.rb
@@ -4,7 +4,7 @@
 #
 
 # Find all cron jobs specified in attributes/cron.rb where current node name matches instance_name
-crons = node[:custom_crons].find_all {|c| c[:instance_name].match "#{node[:name]}" }
+crons = node[:custom_crons].find_all {|c| c[:instance_name] == "#{node[:name]}" }
 
 crons.each do |cron|
   cron cron[:name] do


### PR DESCRIPTION
This avoids a false match on unnamed instances like app_master and db_master