### PR TITLE
prevent exception in eybackup_slave when backups are disabled in an environment

### DIFF
--- a/cookbooks/eybackup_slave/recipes/default.rb
+++ b/cookbooks/eybackup_slave/recipes/default.rb
@@ -5,7 +5,8 @@
 
 # backups disabled?
 if node[:backup_window].to_s == "0"
-  raise "Backups are disabled for this environment"
+  Chef::Log.info "Backups are disabled for this environment; skipping eybackup_slave recipe."
+  return
 end
 
 # database is mysql? (EY Cloud already sets up eybackup on the slave for postgres)


### PR DESCRIPTION
Uses a return instead of a raise and prints a log message to the chef log.