### PR TITLE
Change `/etc/hosts` mapping for Redis host to `redis-instance`

### DIFF
--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -14,7 +14,7 @@ Design
 * 1+ utility instances
 * over-commit is enabled by default to ensure the least amount of problems saving your database.
 * 64-bit is required for storing over 2gigabytes worth of keys.
-* /etc/hosts mapping for `redis_instance` so that a hard config can be used to connect
+* /etc/hosts mapping for `redis-instance` so that a hard config can be used to connect
 
 Backups
 --------

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -84,14 +84,14 @@ if ['solo', 'app', 'app_master', 'util'].include?(node[:instance_role])
 
   if redis_instance
     ip_address = `ping -c 1 #{redis_instance[:private_hostname]} | awk 'NR==1{gsub(/\\(|\\)/,"",$3); print $3}'`.chomp
-    host_mapping = "#{ip_address} redis_instance"
+    host_mapping = "#{ip_address} redis-instance"
 
-    execute "Remove existing redis_instance mapping from /etc/hosts" do
-      command "sudo sed -i '/redis_instance/d' /etc/hosts"
+    execute "Remove existing redis-instance mapping from /etc/hosts" do
+      command "sudo sed -i '/redis-instance/d' /etc/hosts"
       action :run
     end
 
-    execute "Add redis_instance mapping to /etc/hosts" do
+    execute "Add redis-instance mapping to /etc/hosts" do
       command "sudo echo #{host_mapping} >> /etc/hosts"
       action :run
     end


### PR DESCRIPTION
Turns out that for a Rails app having an underscore in the hostname portion of the host definition is not handled well. This recipe worked properly with `redis_instance` in one Node.js app and in the Rails console.