### PR TITLE
Reversing thinking_sphinx symlink direction

### DIFF
--- a/cookbooks/thinking-sphinx-3/recipes/thinking_sphinx.rb
+++ b/cookbooks/thinking-sphinx-3/recipes/thinking_sphinx.rb
@@ -27,8 +27,8 @@ node[:sphinx][:apps].each do |app_name|
     end
 
     #symlink config yml
-    link "#{shared_path}/config/thinking_sphinx.yml" do
-      to "#{current_path}/config/thinking_sphinx.yml"
+    link "#{current_path}/config/thinking_sphinx.yml" do
+      to "#{shared_path}/config/thinking_sphinx.yml"
     end
       
     if util_or_app_server?(node[:sphinx][:utility_name])       


### PR DESCRIPTION
thinking_sphinx.yml should symlink from the deployed repo to the shared config area, should it not?