### PR TITLE
Update the Papertrail recipe

### DIFF
--- a/cookbooks/papertrail/README.md
+++ b/cookbooks/papertrail/README.md
@@ -1,0 +1,15 @@
+Papertrail Cookbook for EngineYard EYCloud
+=========
+
+Papertrail is a service that provides hosted log management. See http://help.papertrailapp.com/ for details.
+
+The official guide on how to run Papertrail on Engine Yard is [here](http://help.papertrailapp.com/kb/hosting-services/engine-yard/).
+
+This recipe has been updated with changes from https://github.com/leonsodhi/ey-cloud-recipes/tree/master/cookbooks/papertrail. We also incorporate fixes as we encounter them.
+
+## Usage
+
+Add `include_recipe "papertrail"` to `main/recipes/default.rb`
+
+Add the port and host from papertrailapp.com to `papertrail/recipes/default.rb`
+

--- a/cookbooks/papertrail/recipes/default.rb
+++ b/cookbooks/papertrail/recipes/default.rb
@@ -4,18 +4,22 @@
 #
 # thanks @indirect !
 # Adapted from the original https://github.com/indirect/ey-cloud-recipes/tree/master/cookbooks/papertrail
+# and https://github.com/bhoggard/remote_syslog2
 #
 # This recipe makes EngineYard Gentoo instances send logs to Papertrail (papertrailapp.com).
 # * syslog-ng is used to monitor syslog
-# * remote_syslog is used for other (application, database, etc.) logs
+# * remote_syslog2 is used for other (application, database, etc.) logs
 # * TLS is used instead of UDP
 
 app_name = node[:applications].keys.first
 env = node[:environment][:framework_env]
 PAPERTRAIL_CONFIG = {
-  :syslog_ng_version         => '3.3.5',
-  :remote_syslog_gem_version => '~>1.6',
-  :port                      => 11111111111111, # YOUR PORT HERE
+  :syslog_ng_version         => '3.3.5-r1',
+  :remote_syslog_version     => 'v0.12',
+  :remote_syslog_filename    => 'remote_syslog_linux_amd64.tar.gz',
+  :remote_syslog_checksum    => 'ecb1ed1831ef9645c6379151fae6859bfe7db3ac9c6b096ae4a063dc79930a70',
+  :port                      => 111111111111111, # YOUR PORT HERE
+  :destination_host          => 'HOST.papertrailapp.com', # YOUR HOST HERE
   :hostname                  => [app_name, node[:instance_role], `hostname`.chomp].join('_'),
   :other_logs => [
     '/var/log/engineyard/nginx/*log',
@@ -27,6 +31,9 @@ PAPERTRAIL_CONFIG = {
     '400 0 "-" "-" "-', # seen in ssl access logs
   ],
 }
+remote_syslog_src_filename = PAPERTRAIL_CONFIG[:remote_syslog_filename]
+remote_syslog_src_filepath = "#{Chef::Config['file_cache_path']}#{remote_syslog_src_filename}"
+remote_syslog_extract_path = "#{Chef::Config['file_cache_path']}remote_syslog2/#{PAPERTRAIL_CONFIG[:remote_syslog_checksum]}"
 
 # install syslog-ng
 
@@ -46,19 +53,21 @@ package 'app-admin/syslog-ng' do
   action :install
 end
 
-remote_file '/etc/syslog.papertrail.crt' do
-  source 'https://papertrailapp.com/tools/syslog.papertrail.crt'
-  checksum '7d6bdd1c00343f6fe3b21db8ccc81e8cd1182c5039438485acac4d98f314fe10'
-  mode '0644'
-end
-
 directory '/etc/syslog-ng/cert.d' do
   recursive true
 end
 
-link '/etc/syslog-ng/cert.d/2f2c2f7c.0' do
-  to '/etc/syslog.papertrail.crt'
-  link_type :symbolic
+remote_file '/etc/syslog-ng/cert.d/papertrail-bundle.tar.gz' do
+  source 'https://papertrailapp.com/tools/papertrail-bundle.tar.gz'
+  checksum '5590de7f7f957508eff58767212cae8fa2fb8cf503e5b5b801f32087501060f3'
+  mode '0644'
+end
+
+bash 'extract SSL certificates' do
+  cwd '/etc/syslog-ng/cert.d'
+  code <<-EOH
+    tar xzf papertrail-bundle.tar.gz
+    EOH
 end
 
 template '/etc/syslog-ng/syslog-ng.conf' do
@@ -77,11 +86,36 @@ execute 'restart-syslog-ng' do
   command %{/etc/init.d/syslog-ng restart}
 end
 
-# install remote_syslog daemon
+# remove remote_syslog gem & install remote_syslog2 daemon
 
-execute 'install remote_syslog gem' do
-  command %{gem install remote_syslog -v '#{PAPERTRAIL_CONFIG[:remote_syslog_gem_version]}'}
-  creates '/usr/bin/remote_syslog'
+execute 'stop existing instances of remote_syslog' do
+  command %{/etc/init.d/remote_syslog stop}
+  only_if { ::File.exists?("/etc/init.d/remote_syslog") }
+end
+
+execute 'remove remote_syslog gem' do
+  command %{gem uninstall remote_syslog -x}
+end
+
+execute "Get remote_syslog" do
+  command "wget -O #{remote_syslog_src_filepath} https://github.com/papertrail/remote_syslog2/releases/download/#{PAPERTRAIL_CONFIG[:remote_syslog_version]}/#{PAPERTRAIL_CONFIG[:remote_syslog_filename]}"
+end
+
+bash 'extract and copy executable' do
+  cwd ::File.dirname(remote_syslog_src_filepath)
+  code <<-EOH
+    mkdir -p #{remote_syslog_extract_path}
+    tar xzf #{remote_syslog_src_filename} -C #{remote_syslog_extract_path}
+    mv #{remote_syslog_extract_path}/remote_syslog/remote_syslog /usr/local/bin
+    EOH
+  not_if { ::File.exists?(remote_syslog_extract_path) }
+end
+
+file "/usr/local/bin/remote_syslog" do
+  owner "root"
+  group "root"
+  mode "0755"
+  action :touch
 end
 
 # remote_syslog config file

--- a/cookbooks/papertrail/templates/default/log_files.yml.erb
+++ b/cookbooks/papertrail/templates/default/log_files.yml.erb
@@ -4,6 +4,6 @@ files:
 exclude_patterns:
   - <%= @exclude_patterns.join("\n  - ") %>
 destination:
-  host: logs.papertrailapp.com
+  host: <%= @destination_host %>
   port: <%= @port %>
-ssl_server_cert: /etc/syslog.papertrail.crt
+  protocol: tls

--- a/cookbooks/papertrail/templates/default/remote_syslog.confd.erb
+++ b/cookbooks/papertrail/templates/default/remote_syslog.confd.erb
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Apache License, Version 2.0
 
 NAME="remote_syslog"
-DAEMON="/usr/sbin/${NAME}"
+DAEMON="/usr/local/bin/${NAME}"
 CONFIG="/etc/log_files.yml"
 PIDFILE="/var/run/${NAME}.pid"
-DAEMON_ARGS="-c ${CONFIG} --pid-file ${PIDFILE} --tls"
+DAEMON_ARGS="-c ${CONFIG} --tls"

--- a/cookbooks/papertrail/templates/default/remote_syslog.initd.erb
+++ b/cookbooks/papertrail/templates/default/remote_syslog.initd.erb
@@ -9,7 +9,7 @@ start() {
     ebegin "Starting ${NAME}"
 
     start-stop-daemon --start --pidfile $PIDFILE --name $NAME \
-        --exec /usr/bin/remote_syslog -- $DAEMON_ARGS
+        --exec /usr/local/bin/remote_syslog -- $DAEMON_ARGS
 
     eend $?
 }
@@ -18,7 +18,7 @@ stop() {
     ebegin "Stopping ${NAME}"
 
     start-stop-daemon --stop --pidfile $PIDFILE --name $NAME \
-        --exec /usr/bin/remote_syslog
+        --exec /usr/local/bin/remote_syslog
 
     eend $?
 }

--- a/cookbooks/papertrail/templates/default/syslog-ng.conf.erb
+++ b/cookbooks/papertrail/templates/default/syslog-ng.conf.erb
@@ -43,7 +43,7 @@ destination d_papertrail {
   # UDP (insecure)
   # udp("logs.papertrailapp.com" port(<%= @port %>));
   # TLS
-  tcp("logs.papertrailapp.com" port(<%= @port %>) tls(ca_dir("/etc/syslog-ng/cert.d")) );
+  tcp("<%= @destination_host %>" port(<%= @port %>) tls(ca_dir("/etc/syslog-ng/cert.d")) );
 };
 log {
   source(src); destination(d_papertrail);


### PR DESCRIPTION
This PR has the following changes:

* Incorporates latest changes from https://github.com/leonsodhi/ey-cloud-recipes/tree/master/cookbooks/papertrail

* Adds a README

* Downloads remote_syslog using wget because Github returns HTTP 403 when we try to download remote_syslog with Chef remote_file

* Removes the pidfile from DAEMON_ARGS so that it's not referenced twice in conf.d

This PR also includes the changes in https://github.com/engineyard/ey-cloud-recipes/pull/169 and https://github.com/engineyard/ey-cloud-recipes/pull/166 so those PRs can be closed when this is merged in.