### PR TITLE
Allows easier configuration of redis instance name

### DIFF
--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -24,7 +24,14 @@ This cookbook does not automate nor facilitate any backup method currently.  By 
 Specifics of Usage
 --------
 
-Simply add a utility instance named `redis` and the recipe will use that instance for redis.
+Simply add a utility instance named `redis` and the recipe will use that instance for redis. If the utility instance you wish to use redis on isn't called `redis`, update redis/attributes/default.rb with the correct instance name:
+
+```ruby
+default[:redis] = {
+  :utility_name => "my_custom_name", # default: redis
+  # ...
+}
+```
 
 Changing Defaults
 --------

--- a/cookbooks/redis/attributes/default.rb
+++ b/cookbooks/redis/attributes/default.rb
@@ -1,4 +1,5 @@
 default[:redis] = {
+  :utility_name => "redis",
   :version => "2.6.16",
   :bindport => "6379",
   :unixsocket => "/tmp/redis.sock",

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -4,7 +4,7 @@
 #
 
 if ['util'].include?(node[:instance_role])
-  if node[:name] == 'redis'
+  if node[:name] == node[:redis][:utility_name]
 
     sysctl "Enable Overcommit Memory" do
       variables 'vm.overcommit_memory' => 1
@@ -49,13 +49,13 @@ if ['util'].include?(node[:instance_role])
         :hz => node[:redis][:hz]
       })
     end
-    
+
     # redis-server is in /usr/bin on stable-v2, /usr/sbin for stable-v4
     if Chef::VERSION[/^0.6/]
       bin_path = "/usr/bin/redis-server"
     else
       bin_path = "/usr/sbin/redis-server"
-    end  
+    end
 
     template "/data/monit.d/redis_util.monitrc" do
       owner 'root'


### PR DESCRIPTION
The default utility name for redis chef recipe now configurable like sidekiq and sphinx recipes.