### PR TITLE
Avoid filesystem race condition for sidekiq

### DIFF
--- a/cookbooks/sidekiq/files/default/sidekiq
+++ b/cookbooks/sidekiq/files/default/sidekiq
@@ -58,6 +58,10 @@ start ()
       exit 1
     else
       rm -f "${pid_file}"
+
+      # Ensure that the pid file is definitely gone to avoid a fs race
+      # condition that causes monit to start a rogue sidekiq worker
+      sleep 10
     fi
   fi
 


### PR DESCRIPTION
Occasionally, it will appear that `sidekiq` is not writing a pid
file for the worker that it spawns. What's actually happening is
that the pid file is being written before the `rm -f "${pid_file}"`
that runs before sidekiq has been fully synced to disk, so it's
being written, but then its file dscriptor is being removed from the
file system.

This makes monit think that the worker is not running, so it starts
another.

This change just adds a 10-second sleep immediately after the
pid file removal to (hopefully) ensure that the file does not
get blown away immediately upon writing.