### PR TITLE
set pull-server-side config to false

### DIFF
--- a/cookbooks/le/recipes/configure.rb
+++ b/cookbooks/le/recipes/configure.rb
@@ -12,6 +12,7 @@ end
 execute "le reinit --pull-server-side-config=False" do
   command "/usr/bin/le reinit --pull-server-side-config=False"
   action :run
+end
 
 follow_paths = [
   "/var/log/syslog",

--- a/cookbooks/le/recipes/configure.rb
+++ b/cookbooks/le/recipes/configure.rb
@@ -9,6 +9,10 @@ execute "le register --account-key" do
   not_if { File.exists?('/etc/le/config') }
 end
 
+execute "le reinit --pull-server-side-config=False" do
+  command "/usr/bin/le reinit --pull-server-side-config=False"
+  action :run
+
 follow_paths = [
   "/var/log/syslog",
   "/var/log/auth.log",


### PR DESCRIPTION
Avoids creating a new host each time a new server spins up as per [Logentries docs](https://github.com/logentries/le#using-local-configuration-only).

Not too familiar with Chef, feel free to point out any errors.
