### PR TITLE
Add a custom chef for passenger_monitor4

### DIFF
--- a/cookbooks/passenger_monitor/README.md
+++ b/cookbooks/passenger_monitor/README.md
@@ -1,0 +1,28 @@
+# Custom passenger_monitor4 Custom Chef Recipe for EY Cloud
+
+## Overview
+
+For the Passenger 4 stack, EY Cloud installs a cron job that runs `/engineyard/bin/passenger_monitor4` every minute. This script checks the output of passenger-memory-stats to see if there are any Passenger workers that are using up more than the memory limit. Passenger workers that exceed the memory limit are terminated with `kill -USR1 <pid_of_worker>`; this prevents bloated workers and memory leak issues from bringing down the site.
+
+However, if the worker is busy or is frozen, `kill -USR1 <pid_of_worker>` fails to terminate it. For Passenger versions prior to 4.0.52, this is a known bug, documented in https://github.com/phusion/passenger/wiki/Phusion-Passenger:-Node.js-tutorial#restarting_apps_that_serve_long_running_connections. A workaround in this case is to send a `kill -9 <pid_of_worker>` to the frozen worker.
+
+Immediately sending a `kill -9` is not recommended, however. We want to use it only as a last resort; for normal cases we want to give the worker a chance to clean up. For e-commerce sites that involve transactions we want to avoid `kill -9` as much as possible because it can lead to credit cards getting charged but orders not being flagged for delivery.
+
+This custom chef recipe includes an updated `/engineyard/bin/passenger_monitor4` with a `grace_time` option (-w). When a worker is terminated with `kill -USR1`, we'll verify if the worker process was actually killed. If the worker process is still alive after `grace_time` seconds, we'll send the worker a `kill -9` to really terminate it.
+
+```
+NOTE: If a worker has exceeded the memory limit and has been marked for termination, it will be terminated within `grace_time` seconds, even if the worker has recovered and memory consumption has decreased below the limit within the time.
+```
+
+Engine Yard is still in the process of evaluating this updated `/engineyard/bin/passenger_monitor4` script. Getting this integrated into the Passenger main chef recipe may take some time. In the meantime, customers who wish to implement the `kill -9` with `grace_time` logic can use this custom chef recipe.
+
+
+## Installation and Usage
+
+Include the recipe in `cookbooks/main/recipes/default.rb`:
+
+```
+include_recipe 'passenger_monitor'
+```
+
+Customize the application name, memory limit, and grace_time in `cookbooks/passenger_monitor/attributes/default.rb`.

--- a/cookbooks/passenger_monitor/attributes/default.rb
+++ b/cookbooks/passenger_monitor/attributes/default.rb
@@ -1,0 +1,12 @@
+default[:passenger_monitor4] = {
+  # your EY Cloud application name
+  :app_name => "myapp",
+
+  # passenger worker memory limit, in MB
+  :memory_limit => 300,
+
+  # When a worker hits or exceeds the memory limit, we attempt to kill it with kill -USR1 <PID>
+  # Due to this bug: https://github.com/phusion/passenger/wiki/Phusion-Passenger:-Node.js-tutorial#restarting_apps_that_serve_long_running_connections,
+  # kill -USR1 does not always succeed. When that happens we send a kill -9 <PID> after waiting grace_time seconds
+  :grace_time => 30
+}

--- a/cookbooks/passenger_monitor/files/default/passenger_monitor4
+++ b/cookbooks/passenger_monitor/files/default/passenger_monitor4
@@ -1,0 +1,115 @@
+#!/bin/bash
+#===============================================================================
+script_name="passenger_monitor"
+script_author="James Paterni, Dennis Bell, Jim Neath, Radamanthus Batnag"
+script_version="0.1.0"
+#===============================================================================
+# This script monitors passenger application instances and gracefully restarts
+#   any monitored instances exceeding the configured (real) memory limit and
+#   kills any orphaned instances
+#
+# * Ensure this script is executable (chmod +x)
+#===============================================================================
+
+target_app=$1
+
+# Check user is root.
+if [ "`whoami`" != "root" ]; then
+  logger -t `basename $0` -s "Must be run as root"
+  exit 1
+fi
+
+## Defaults 
+# memory limit - override with -l <limit in MB>
+# grace time - how long to wait before doing a kill -9 - override with -w <grace_time in seconds>
+limit=250
+grace_time=30
+
+shift
+while getopts "l:w:" opt; do
+  case $opt in
+    l)
+      limit=$OPTARG
+      ;;
+    w)
+      grace_time=$OPTARG
+      ;;
+  esac
+done
+
+let "grace_time=$grace_time*4"
+
+## Get output from passenger-memory-stats, egrep for RailsApp: OR RackApp:.
+## Sed explained:
+##  /MB/!d; - Do not delete lines with MB in them. All others are removed (check for memory output)
+##  s/(^[0-9]+)\s.*(\b[0-9]+)\.[0-9]+\sMB.*MB.*/\1-\2/' ... Explained in segments below...
+##      s/ -- Tell sed that this is a search and replace function.
+##      ^(^[0-9]+)\s* -- Get the pid (First set of numbers at beginning of string).
+##      (\b[0-9]+)\.[0-9]+\sMB\s+ -- Grab the virtual memory for each process. Must begin with a word break (i.e. space), have numbers, a dot, more numbers a space and MB. Only the integer half of the number is grabbed.
+##      (\b[0-9]+)\.[0-9]+\sMB -- same thing for the real memory for each process
+##      .*\/([^\/]+)\/current -- grab the application name out of the path
+##      \1,\2,\3,\4/ -- assembe the selected values into a comma-separated-list, to later be converted into an array
+
+# Create an array variable
+declare -a info
+
+for record in `passenger-memory-stats | egrep -i "Passenger Ra(ils|ck)App:" | sed -r '/MB/!d;s/(^[0-9]+)\s*(\b[0-9]+)\.[0-9]\sMB\s+(\b[0-9]+)\.[0-9]+\sMB.*\/([^\/]+)\/current/\1,\2,\3,\4/'`; do
+
+  # Turn the record into an array, and assign to local variables for clarity
+  info=(`echo ${record//,/ }`)
+  app_pid=${info[0]}
+  app_virt=${info[1]} # reserved for future use
+  app_real=${info[2]}
+  app_name=${info[3]}
+
+  if [[ "$app_name" != "$target_app" ]]; then
+    continue
+  fi
+
+  ## Check the against the limit, if it exceeds the memory amount, KILL IT.
+  if [[ $app_real -gt $limit ]]; then
+    logger -t passenger_monitor -s "Killing PID $app_pid (app $app_name) - memory $app_real MB exceeds $limit MB"
+    kill -USR1 $app_pid
+    SLEEP_COUNT=0
+    while [ -e /proc/$app_pid ]; do
+      sleep .25
+      let "SLEEP_COUNT+=1"
+      let "REPORT_TIME = $SLEEP_COUNT%4"
+      if(( "$SLEEP_COUNT" > $grace_time )); then
+        logger -t passenger_monitor -s "Stopping Passenger worker Process $app_pid wait exceeded, killing it"
+        kill -9 $app_pid 2>/dev/null; true
+        break
+      elif(( $REPORT_TIME == 0 ));then
+        let "RUNTIME = $SLEEP_COUNT/4"
+        logger -t passenger_monitor -s "Waiting for $app_pid to die ( for $RUNTIME seconds now)"
+      fi
+    done
+  fi
+done
+
+## Passenger 2 stale passenger.<x> fix:
+## Remove stale passenger.<x> directories to prevent
+## multiple passenger instance running error.
+for each in /tmp/passenger.*;do 
+  if [[ -d ${each}/info ]]; then  # This is passenger 2?
+    if [[ ! -e ${each}/info/status.socket ]]; then  # Remove stale directories.
+      rm -rf ${each}
+    fi
+  fi
+done
+
+## Get a list of passenger workers.
+raw_stats=$(/usr/sbin/passenger-status 2>> /tmp/passenger_errors)
+exit_code=$?
+
+## Kill any passenger workers that are not in $pstats
+if [ "$exit_code" -eq "0" ] ; then
+  pstats=$(echo "$raw_stats" | sed -r -e '/PID:/!d' -e 's/.*PID:\s([0-9]+).*/\1/' | sort -n| uniq)
+  for pid in `diff <(ps aux | egrep -i 'Passenger Ra(ils|ck)App:' | awk '{print $2}' | sort -n) <(echo "$pstats") | grep '<' | awk '{print $2}'`; do
+    kill -9 $pid
+    logger -t passenger_monitor -s "Killing PID $pid - orphaned process"
+  done
+else
+  logger -t passenger_monitor -s "Could not read passenger-status [Status:$exit_code]"
+  logger -t passenger_monitor -s "$raw_stats"
+fi

--- a/cookbooks/passenger_monitor/recipes/default.rb
+++ b/cookbooks/passenger_monitor/recipes/default.rb
@@ -1,0 +1,23 @@
+app_name = node[:passenger_monitor4][:app_name]
+memory_limit = node[:passenger_monitor4][:memory_limit]
+grace_time = node[:passenger_monitor4][:grace_time]
+
+# Installs the updated passenger_monitor4 script
+cookbook_file "/engineyard/bin/passenger_monitor4" do
+  owner "root"
+  group "root"
+  mode 0755
+  source "passenger_monitor4"
+  backup false
+  action :create
+end
+
+# Updates the passenger_monitor_appname cron job
+cron "passenger_monitor_#{app_name}" do
+  minute '*'
+  hour '*'
+  day '*'
+  weekday '*'
+  month '*'
+  command "/usr/bin/lockrun --lockfile=/var/run/passenger_monitor4_#{app_name}.lockrun -- /bin/bash -c '/engineyard/bin/passenger_monitor4 #{app_name} -l #{memory_limit} -w #{grace_time} >/dev/null 2>&1'"
+end


### PR DESCRIPTION
This includes a modified passenger_monitor4 that sends a kill -9 to terminate frozen workers.
See https://github.com/radamanthus/ey-cloud-recipes/blob/passenger_monitor/cookbooks/passenger_monitor/README.md for details