### PR TITLE
datadog support

### DIFF
--- a/cookbooks/datadog/attributes/default.rb
+++ b/cookbooks/datadog/attributes/default.rb
@@ -1,0 +1,12 @@
+# Throw your DataDog API key here
+default['datadog']['api_key'] = ""
+
+# Where do you install you extra monits?
+default['monit']['directory'] = "/etc/monit.d"
+
+#dont change unless you change this in the monit config
+default['wrapper']['directory'] = "/opt"
+
+# directory for your nginx custom config
+default['nginx']['custom'] = ""
+

--- a/cookbooks/datadog/files/default/datadog.monitrc
+++ b/cookbooks/datadog/files/default/datadog.monitrc
@@ -1,0 +1,5 @@
+check process datadog_wrapper
+  with pidfile /var/run/datadog_wrapper.pid
+  start program = "/bin/datadog_wrapper start"
+  stop program = "/bin/datadog_wrapper stop"
+  group datadog

--- a/cookbooks/datadog/files/default/datadog_wrapper.sh
+++ b/cookbooks/datadog/files/default/datadog_wrapper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+case $1 in
+  start)
+     echo $$ > /var/run/datadog_wrapper.pid
+     /bin/bash /root/.datadog-agent/bin/agent start
+     ;;
+   stop)
+     kill `cat /var/run/datadog_wrapper.pid`
+     kill `cat /root/.datadog-agent/run/supervisord.pid`
+     ;;
+   *)
+     echo "usage: datadog_wrapper {start|stop}" ;;
+esac
+exit 0

--- a/cookbooks/datadog/files/default/setup_agent.sh
+++ b/cookbooks/datadog/files/default/setup_agent.sh
@@ -1,0 +1,455 @@
+#!/bin/sh
+
+####################################################
+#  THIS IS A CUSTOM VERSION OF THE DATADOG INSTALL #
+#                                                  #
+#                 MAJOR DIFFERENCE:                #
+#                                                  #
+#       THE SCRIPT EXITS INSTEAD OF STARTING       #
+#       THE DATADOG AGENT IN THE FOREGROUND        #
+#                                                  #
+#        ALEX - EZCATER, INC - @alexmoreale        #
+####################################################
+
+# figure out where to pull from
+tag="5.6.3"
+
+PIP_VERSION="6.0.6"
+
+#######################
+# Define some helpers #
+#######################
+
+dogweb_reporting_failure_url="https://app.datadoghq.com/agent_stats/report_failure"
+email_reporting_failure="support@datadoghq.com"
+agent_help_page="http://docs.datadoghq.com/guides/basic_agent_usage/"
+see_agent_on_datadog_page="https://app.datadoghq.com/infrastructure"
+
+RED="\033[31m"
+GREEN="\033[32m"
+DEFAULT="\033[0m"
+
+# Function to display a message passed as an argument in red and then exit
+quit_error() {
+  printf "$RED"
+  printf "$1" | tee -a $logfile
+  printf "\nExiting...\n" | tee -a $logfile
+  printf "$DEFAULT"
+  exit 1
+}
+
+get_api_key_to_report() {
+    if [ $apikey ]; then
+        key_to_report=$apikey
+    else
+        key_to_report="No_key"
+    fi
+}
+
+# Try to use curl to post the log in case of failure to an endpoint
+# Will try to send it by mail usint the mail function if curl failed
+report() {
+    get_api_key_to_report
+    log=$(cat "$logfile")
+    encoded_log=$(echo "$log" | python -c 'import sys, urllib; print urllib.quote(sys.stdin.read().strip())')
+    OS=$(echo "$unamestr" | python -c 'import sys, urllib; print urllib.quote(sys.stdin.read().strip())')
+    key_to_report=$(echo "$key_to_report" | python -c 'import sys, urllib; print urllib.quote(sys.stdin.read().strip())')
+    agent_version=$(echo "$tag" | python -c 'import sys, urllib; print urllib.quote(sys.stdin.read().strip())')
+    notification_message="$RED
+A notification has been sent to Datadog with the content of $logfile.
+
+Troubleshooting and basic usage information for the Agent are available at:
+
+    $agent_help_page
+
+If you're still having problems please send an email to $email_reporting_failure
+and we'll do our very best to help you solve your problem.\n$DEFAULT"
+
+    curl -f -s -d "version=$agent_version&os=$OS&apikey=$key_to_report&log=$encoded_log" $dogweb_reporting_failure_url >> $logfile 2>&1 && printf "$notification_message" || report_using_mail
+
+    exit 1
+
+}
+
+# If the user doesn't want to automatically report, display a message so he can reports manually
+report_manual() {
+
+   printf "$RED
+Troubleshooting and basic usage information for the Agent are available at:
+
+    $agent_help_page
+
+If you're still having problems, please send an email to $email_reporting_failure
+with the content of $logfile and any
+information you think would be useful and we'll do our very best to help you
+solve your problem.
+
+\n$DEFAULT"
+
+ exit 1
+
+}
+
+# Try to send the report using the mail function if curl failed, and display
+# a message in case the mail function also failed
+report_using_mail() {
+    log=$(cat "$logfile")
+    notfication_message_manual="$RED
+Unable to send the report (you need curl or mail to send the report).
+
+Troubleshooting and basic usage information for the Agent are available at:
+
+    $agent_help_page
+
+If you're still having problems, please send an email to $email_reporting_failure
+with the content of $logfile and any
+information you think would be useful and we'll do our very best to help you
+solve your problem.
+
+
+\n$DEFAULT"
+
+    printf "$log" | mail -s "Agent source installation failure" $email_reporting_failure  2>> $logfile && printf "$notification_message" | tee -a $logfile || printf "$notfication_message_manual" | tee -a $logfile
+
+exit 1
+
+}
+
+# Will be called if an unknown error appears and that the Agent is not running
+# It asks the user if he wants to automatically send a failure report
+unknown_error() {
+  printf "$RED It looks like you hit an issue when trying to install the Agent.\n$DEFAULT" | tee -a $logfile
+  printf "$1" | tee -a $logfile
+
+  while true; do
+    read -p "Do you want to send a failure report to Datadog (Content of the report is in $logfile)? (y/n)" yn
+    case $yn in
+        [Yy]* ) report; break;;
+        [Nn]* ) report_manual; break;;
+        * ) echo "Please answer yes or no.";;
+    esac
+  done
+}
+
+
+# Small helper to display "Done"
+print_done() {
+  printf "$GREEN"
+  printf "Done\n" | tee -a $logfile
+  printf "$DEFAULT"
+}
+
+unamestr=`uname`
+
+
+#################################
+# Beginning of the installation #
+#################################
+
+printf "\n\nInstalling Datadog Agent $tag\n\n\n"
+
+
+if [ -n "$DD_API_KEY" ]; then
+    apikey=$DD_API_KEY
+fi
+
+if [ -n "$DD_HOME" ]; then
+    dd_home=$DD_HOME
+fi
+
+if [ -n "$DD_START_AGENT" ]; then
+    start_agent=$DD_START_AGENT
+else
+    start_agent=1
+fi
+
+if [ -n "$IS_OPENSHIFT" ]; then
+    is_openshift=$IS_OPENSHIFT
+else
+    is_openshift=0
+fi
+
+
+# Checking sysstat is installed
+if [ "$unamestr" != "Darwin" ]; then
+  iostat > /dev/null 2>&1
+  success=$?
+  if [ $success != 0 ]; then
+    quit_error "sysstat is not installed in your system
+If you run CentOs/RHEL, you can install it by running:
+  sudo yum install sysstat
+If you run Debian/Ubuntu, you can install it by running:
+  sudo apt-get install sysstat"
+  fi
+fi
+
+# Check python >= 2.6 is installed
+python -c "import sys; exit_code = 0 if sys.version_info[0]==2 and sys.version_info[1] > 5 else 66 ; sys.exit(exit_code)" > /dev/null 2>&1
+success=$?
+if [ $success != 0 ]; then
+  quit_error "Python 2.6 or 2.7 is required to install the Agent from source."
+fi
+
+# Determining which command to use to download files
+if [ $(which curl) ]; then
+    dl_cmd="curl -k -L -o"
+else
+    dl_cmd="wget -O"
+fi
+
+# create home base for the Agent
+if [ $dd_home ]; then
+  dd_base=$dd_home
+else
+  if [ "$unamestr" = "SunOS" ]; then
+      dd_base="/opt/local/datadog"
+  else
+      dd_base=$HOME/.datadog-agent
+  fi
+fi
+
+
+printf "Creating Agent directory $dd_base....."
+mkdir -p $dd_base
+printf "$GREEN Done\n$DEFAULT"
+
+logfile="$dd_base/ddagent-install.log"
+printf "Creating log file $logfile....." | tee -a $logfile
+print_done
+
+# Log the operating system version
+printf "Operating System: $unamestr\n" >> $logfile
+
+# set up a virtual env
+printf "Setting up virtual environment....." | tee -a $logfile
+$dl_cmd $dd_base/virtualenv.py https://raw.githubusercontent.com/pypa/virtualenv/1.11.6/virtualenv.py >> $logfile 2>&1
+
+if [ "$is_openshift" = "1" ]; then
+    python $dd_base/virtualenv.py --no-pip --no-setuptools --system-site-packages $dd_base/venv >> $logfile 2>&1
+else
+    python $dd_base/virtualenv.py --no-pip --no-setuptools $dd_base/venv >> $logfile 2>&1
+fi
+
+. $dd_base/venv/bin/activate >> $logfile 2>&1
+print_done
+
+# set up setuptools and pip with wheels support
+printf "Setting up setuptools and pip....." | tee -a $logfile
+$dl_cmd $dd_base/ez_setup.py https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py >> $logfile 2>&1
+$dd_base/venv/bin/python $dd_base/ez_setup.py >> $logfile 2>&1
+$dl_cmd $dd_base/get-pip.py https://bootstrap.pypa.io/get-pip.py >> $logfile 2>&1
+$dd_base/venv/bin/python $dd_base/get-pip.py >> $logfile 2>&1
+$dd_base/venv/bin/pip install pip==$PIP_VERSION >> $logfile 2>&1
+print_done
+
+# install dependencies
+printf "Installing requirements using pip....." | tee -a $logfile
+$dl_cmd $dd_base/requirements.txt https://raw.githubusercontent.com/DataDog/dd-agent/$tag/requirements.txt  >> $logfile 2>&1
+$dd_base/venv/bin/pip install -r $dd_base/requirements.txt >> $logfile 2>&1
+rm $dd_base/requirements.txt
+print_done
+
+printf "Trying to install optional dependencies using pip....." | tee -a $logfile
+$dl_cmd $dd_base/requirements.txt https://raw.githubusercontent.com/DataDog/dd-agent/$tag/requirements-opt.txt  >> $logfile 2>&1
+while read DEPENDENCY
+do
+    ($dd_base/venv/bin/pip install $DEPENDENCY || printf "Cannot install $DEPENDENCY. There is probably no Compiler on the system.") >> $logfile 2>&1
+done < $dd_base/requirements.txt
+rm $dd_base/requirements.txt
+print_done
+
+# set up the Agent
+mkdir -p $dd_base/agent >> $logfile 2>&1
+
+printf "Downloading the latest version of the Agent from github (~2.5 MB)....." | tee -a $logfile
+$dl_cmd $dd_base/agent.tar.gz https://github.com/DataDog/dd-agent/tarball/$tag >> $logfile 2>&1
+print_done
+printf "Uncompressing the archive....." | tee -a $logfile
+tar -xz -C $dd_base/agent --strip-components 1 -f $dd_base/agent.tar.gz >> $logfile 2>&1
+print_done
+
+printf "Configuring datadog.conf file......" | tee -a $logfile
+if [ $apikey ]; then
+    sed "s/api_key:.*/api_key: $apikey/" $dd_base/agent/datadog.conf.example > $dd_base/agent/datadog.conf 2>> $logfile
+    chmod 640 $dd_base/agent/datadog.conf
+else
+  printf "No api key set. Assuming there is already a configuration file present." | tee -a $logfile
+fi
+
+if [ "$unamestr" = "SunOS" ]; then
+    # disable syslog by default on SunOS as it causes errors
+    sed -i "s/# log_to_syslog: yes/log_to_syslog: no/" $dd_base/agent/datadog.conf 2>> $logfile
+fi
+printf "disable_file_logging: True" >> $dd_base/agent/datadog.conf
+
+print_done
+
+printf "Setting up launching scripts....." | tee -a $logfile
+mkdir -p $dd_base/bin >> $logfile 2>&1
+cp $dd_base/agent/packaging/datadog-agent/source/agent $dd_base/bin/agent >> $logfile 2>&1
+cp $dd_base/agent/packaging/datadog-agent/source/info  $dd_base/bin/info >> $logfile 2>&1
+chmod +x $dd_base/bin/agent >> $logfile 2>&1
+chmod +x $dd_base/bin/info >> $logfile 2>&1
+print_done
+
+# This is the script that will be used by SMF
+if [ "$unamestr" = "SunOS" ]; then
+    cp $dd_base/agent/packaging/datadog-agent/smartos/dd-agent $dd_base/bin/dd-agent >> $logfile 2>&1
+    chmod +x $dd_base/bin/dd-agent >> $logfile 2>&1
+fi
+
+# set up supervisor
+printf "Setting up supervisor....." | tee -a $logfile
+mkdir -p $dd_base/supervisord/logs >> $logfile 2>&1
+$dd_base/venv/bin/pip install supervisor==3.0b2 >> $logfile 2>&1
+cp $dd_base/agent/packaging/datadog-agent/source/supervisord.conf $dd_base/supervisord/supervisord.conf >> $logfile 2>&1
+mkdir -p $dd_base/run
+print_done
+
+if [ "$unamestr" = "Darwin" ]; then
+    # prepare launchd
+    mkdir -p $dd_base/launchd/logs >> $logfile 2>&1
+    touch $dd_base/launchd/logs/launchd.log >> $logfile 2>&1
+    sed "s|AGENT_BASE|$dd_base|; s|USER_NAME|$(whoami)|" $dd_base/agent/packaging/datadog-agent/osx/com.datadoghq.Agent.plist.example > $dd_base/launchd/com.datadoghq.Agent.plist
+fi
+
+# consolidate logging
+printf "Consolidating logging....." | tee -a $logfile
+mkdir -p $dd_base/logs >> $logfile 2>&1
+ln -s $dd_base/supervisord/logs $dd_base/logs/supervisord >> $logfile 2>&1
+if [ "$unamestr" = "Darwin" ]; then
+    ln -s $dd_base/launchd/logs $dd_base/logs/launchd >> $logfile 2>&1
+fi
+print_done
+
+# clean up
+printf "Cleaning up the installation directory....." | tee -a $logfile
+rm $dd_base/virtualenv.py >> $logfile 2>&1
+rm $dd_base/virtualenv.pyc >> $logfile 2>&1
+rm $dd_base/agent.tar.gz >> $logfile 2>&1
+print_done
+
+# on solaris, skip the test, svcadm the Agent
+if [ "$unamestr" = "SunOS" ]; then
+    # Install pyexpat for our version of python, a dependency for xml parsing (varnish et al.)
+    # Tested with /bin/sh
+    python -V 2>&1 | awk '{split($2, arr, "."); printf("py%d%d-expat", arr[1], arr[2]);}' | xargs pkgin -y in
+    # SMF work now
+    svccfg import $dd_base/agent/packaging/datadog-agent/smartos/dd-agent.xml >> $logfile 2>&1
+    svcadm enable site/datadog >> $logfile 2>&1
+    svcs datadog >> $logfile 2>&1
+
+    printf "*** The Agent is running. My work here is done... ( ^_^) ***" | tee -a $logfile
+    printf "
+
+                                         7           77II?+~,,,,,,
+                                        77II?~:,,,,,,,,,,,,,,,,,,,
+                           77I?+~:,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,I
+   7         77II?+~,,,,,,,,,,,,,,,,,,,,,,,,,,,,I :,,,,,,,,,,,,,,,:
+  II?=:,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,:   ~  +,,,,,,,,,,,,,,
+  ,,,,,,,,,,,,,,,,,=7:,,,,,,,,,,,,,,,,,,,,,,~    =   7,,,,,,,,,,,,,7
+  ,,,,,,,,,,,,,=     =7,,,,,,,,,,, ~7:I,,,:      7I    ,,,,,,,,,,,,I
+  ,,,,,,,,,,,,7       ,  ,,,,,=                   ,7    ,,,,,,,,,,,,
+  I,,,,,,,,,,         +~                     7:I  ,,   7 ,,,,,,,,,,,
+   ,,,,,,,,+           ,I                     7 ,+ ,,I   +,,,,,,,,,,7
+   ,,,,,,,,            ,,                        ,,,,,,I7?,,,,,,,,,,+
+   :,,,,,,,            7,                         ,,,,,,,,,,,,,,,,,,,
+   7,,,,,,,7            ,7                         ,,,,,,,,,,,,,,,,,,
+    ,,,,,,,,7           ,7                    7,,,I ,,,,,,,,,,,,,,,,,7
+    ,,,,,,,,,I         7,7      7I:,,:         I,,,7:,,,,,,,,,,,,,,,,=
+    =,,,,,,,,,,       I,,      7,,,,,  7        ?,, =,,,,,,,,,,,,,,,,,
+    7,,,,,,,,,,,,I77?,,,       =,,,,,7              ?,,,,,,,,,,,,,,,,,
+     ,,,,,,,,,,,,,,,,,          ,,,=                 7,,,,,,,,,,,,,,,,
+     ,,,,,,,,,,,,=                                     ,,,,,,,,,,,,,,,7
+     ,,,,,,,,,,,,:                                      ,,,,,,,,,,,,,,=
+     ~,,,,,,,,,,,, 7                             I?~,,,7 ,,,,,,,,,,,,,,
+     7,,,,,,,,,,,,I                            7,,,,,,,7 ,,,,,,,,,,,,,,
+      ,,,,,,,,,,,,,  7                          ,,,,,,,7 ,,,,,,,,,,,,,,I
+      ,,,,,,,,,,,,,7 7                            ~,,:   ,,,,,,,,,,,,,,:
+      =,,,,,,,,,,,,:,7           I                 77   ?,,,,,,,,,,,,,,,
+      7,,,,,,,,,,,,,,,          7 ,7              7,    ,,,,,,,,,,,,,:,,7 7
+       ,,,,,,,,,,,,,,,,,           :,I           7,,+?~,,,,,:?       7,,I
+       ,,,,,,,,,,,,,,,,,:            ,,,I      7+,,,=                 ,,,
+       ?,,,,,,,,,,,,,,,,,        +:,,,,,,,,,,,,,,                     ,,,
+        ,,,,,,,,,,,,,,,,,        7,7       ~,~   7                7,  ,,,77
+        ,,,,,,,,,,,,,,,,,         ,=                     7       I,,7 ,,,+
+        ,,,,,,,,,,,,,,,,I         ,,                    7       7,,,7 ,,,,
+        I,,,,,,,,,,,,,,           ,,                   ,,,I    I,,,,+ ,,,,
+         ,,,,,,,,,,,,7  7         +,                  ?,,,,,7 =,,,,,: ,,,,7
+         ,,,,,,,,,,?+,,,,,,?      7,7               7?,,,,,,,,,,,,,,, =,,,=
+         :,,,,,,,,,       7,,I     ,=        ~I     I,,,,,,,,,,,,,,,, 7,,,,
+         7,,,,,,            ,,     ,,     7 ?,,,~7 I,,,,,,,,,,,,,,,,, 7,,,,
+          ,,,,,              ,,    ,,     7+,,,,,,,,,,,,,,,,,,,,,,,,,7 ,,,,
+          ,,,,                ,I   ,,     +,,,,,,,,,,,,,,,,,,,,,,,,,,I ,,,,7
+          ,,,,7               ,,   =,7  7+,,,,,,,,,,,,,,,,,,,,,,,,,,,= ,,7
+          :,,,:               I,III=,=  =,,,,,,,,,,,,,,,,,,,,,~7   7  7,,=
+          7,,,,:              7,,,,,,,  ,,,,,,,,,,,,,,+       7I?~,,,,,,,,
+           ,,,,,,              ,=7 7,,  ,,,,,=    7  7I?=,,,,,,,,,,,,,,,,,7
+           ,,,,,,:            7,    ,,       II+:,,,,,,,,,,,,,,,,,,~?
+                  7           :,    ,,?~,,,,,,,,,,,,,,:?
+                              ,+    ,,,,,:=7
+                    I       7,,
+                    I,,~++:,,,
+                       ?:,:I 7
+    " | tee -a $logfile
+    # kthxbye
+    exit $?
+else
+  if [ "$start_agent" = "1" ]; then
+      printf "Starting the Agent....." | tee -a $logfile
+      # run Agent
+      cd $dd_base >> $logfile 2>&1
+      supervisord -c $dd_base/supervisord/supervisord.conf >> $logfile 2>&1 &
+      agent_pid=$!
+      sleep 1
+      # Checking that supervisord was properly launched
+      kill -0 $agent_pid > /dev/null 2>&1
+      supervisor_running=$?
+
+      if [ $supervisor_running != 0 ]; then
+        unknown_error "Failure when launching supervisor.\n"
+
+      fi
+      trap "{ kill $agent_pid; exit 255; }" INT TERM
+      trap "{ kill $agent_pid; exit; }" EXIT
+      print_done
+
+
+      # wait for metrics to be submitted
+      printf "$GREEN
+  Your Agent has started up for the first time. We're currently verifying
+  that data is being submitted. You should see your Agent show up in Datadog
+  shortly at:
+
+      $see_agent_on_datadog_page $DEFAULT" | tee -a $logfile
+
+    printf "\n\nWaiting for metrics..." | tee -a $logfile
+
+      c=0
+      # Wait for 30 secs before checking if metrics have been submitted
+      while [ "$c" -lt "30" ]; do
+          sleep 1
+          printf "."
+          c=$(($c+1))
+      done
+
+      # Hit this endpoint to check if the Agent is submitting metrics
+      # and retry every sec for 60 more sec before failing
+      curl -f http://localhost:17123/status?threshold=0 >> $logfile 2>&1
+      success=$?
+      while [ "$success" -gt "0" ]; do
+          sleep 1
+          printf "."
+          curl -f http://localhost:17123/status?threshold=0 >> $logfile 2>&1
+          success=$?
+          c=$(($c+1))
+          if [ "$c" -gt "90" ]; then
+            unknown_error "Agent did not submit metrics after 90 seconds
+            "
+          fi
+      done
+
+      # print instructions
+#      exit 0 # additional line i added
+  fi
+fi

--- a/cookbooks/datadog/recipes/config.rb
+++ b/cookbooks/datadog/recipes/config.rb
@@ -1,0 +1,20 @@
+ey_cloud_report "datadog" do
+ message "DataDog::Custom Config Start"
+end
+
+template '/root/.datadog-agent/agent/datadog.conf' do
+  source 'datadog.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '640'
+  variables({
+    :hostname => node[:hostname],
+    :role => node[:instance_role],
+    :env_name => node[:environment][:name],
+    :api_key => node.default[:datadog][:api_key],
+  })
+end
+
+ey_cloud_report "datadog" do
+ message "DataDog::Custom Config End"
+end

--- a/cookbooks/datadog/recipes/daemonize.rb
+++ b/cookbooks/datadog/recipes/daemonize.rb
@@ -1,0 +1,42 @@
+#
+# wrapper script will you need to dameonize the script the use to start the
+
+ey_cloud_report "datadog" do
+ message "DataDog::Daemonize Start"
+end
+
+cookbook_file "copy in the wrapper script" do
+	path "#{node['wrapper']['directory']}/datadog_wrapper.sh"
+  source "datadog_wrapper.sh"
+  owner "root"
+  group "root"
+  mode "744"
+  not_if "test -f #{node['wrapper']['directory']}/datadog_wrapper.sh"
+end
+
+link "dd-link" do
+  owner "root"
+  target_file "/bin/datadog_wrapper"
+	to "#{node['wrapper']['directory']}/datadog_wrapper.sh"
+end
+
+execute 'monit-reload' do
+  command 'monit reload'
+  action :nothing
+end
+
+cookbook_file "copy in the datadog monit" do
+	path "#{node['monit']['directory']}/datadog.monitrc"
+  source "datadog.monitrc"
+  owner "root"
+  group "root"
+  mode "644"
+	not_if "test -f #{node['monit']['directory']}/datadog.monitrc"
+  notifies :run, 'execute[monit-reload]', :immediately
+end
+
+
+
+ey_cloud_report "datadog" do
+  message "DataDog::Daemonize End"
+end

--- a/cookbooks/datadog/recipes/default.rb
+++ b/cookbooks/datadog/recipes/default.rb
@@ -23,10 +23,12 @@ include_recipe "datadog::daemonize"
 # comment out if you want to use the standard config
 include_recipe "datadog::config"
 
+#uncomment this for the nginx integrations to work
+
 # on app servers and staging install the nginx integrations
-if ['app_master','app','solo'].include? node[:instance_role]
-  include_recipe "datadog::nginx"
-end
+#if ['app_master','app','solo'].include? node[:instance_role]
+#  include_recipe "datadog::nginx"
+#end
 
 # finish up
 include_recipe "datadog::finish"

--- a/cookbooks/datadog/recipes/default.rb
+++ b/cookbooks/datadog/recipes/default.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: datadog
+# Recipe:: default
+#
+
+# Set your API key in the default attributes file or the Chef run will fail
+# raise if node['datadog']['api_key'].nil? || node['datadog']['api_key'].empty?
+
+# stop the agent before the install if it is already on there
+execute "monit-stop-dd" do
+ user "root"
+ cwd "/"
+ command "monit stop datadog_wrapper"
+ only_if { File.exists?( '/var/run/datadog_wrapper.pid') }
+end
+
+# the dd setup script installs the agent
+include_recipe "datadog::install"
+
+# use monit and a wrapper script
+include_recipe "datadog::daemonize"
+
+# comment out if you want to use the standard config
+include_recipe "datadog::config"
+
+# on app servers and staging install the nginx integrations
+if ['app_master','app','solo'].include? node[:instance_role]
+  include_recipe "datadog::nginx"
+end
+
+# finish up
+include_recipe "datadog::finish"

--- a/cookbooks/datadog/recipes/finish.rb
+++ b/cookbooks/datadog/recipes/finish.rb
@@ -1,0 +1,5 @@
+
+execute "monit-start-dd" do
+ user "root"
+ command "monit start datadog_wrapper"
+end

--- a/cookbooks/datadog/recipes/install.rb
+++ b/cookbooks/datadog/recipes/install.rb
@@ -1,0 +1,36 @@
+#
+#oh you thought you could emerge this on gentoo....nope welcome
+#
+
+ey_cloud_report "datadog" do
+ message "DataDog::Install Start"
+end
+
+cookbook_file 'copy in setup script' do
+	path '/root/setup_agent.sh'
+  source 'setup_agent.sh'
+  owner 'root'
+  group 'root'
+  mode '744'
+	not_if { File.exists?( '/root/setup_agent.sh')  }
+end
+
+bash 'run the setup script' do
+ user 'root'
+ cwd '/root'
+ code <<-EOH
+  DD_API_KEY=#{node['datadog']['api_key']} sh ./setup_agent.sh
+	EOH
+ notifies :run, 'execute[rm-setup-tools]', :immediately
+ not_if "test -f /root/.datadog-agent/bin/agent"
+end
+
+execute 'rm-setup-tools' do
+ command "find /root -name 'setuptools-*.zip' | xargs rm"
+ action :nothing
+ only_if { !Dir.glob('/root/setuptools*.zip').empty? }
+end
+
+ey_cloud_report "datadog" do
+ message "DataDog::Install End"
+end

--- a/cookbooks/datadog/recipes/nginx.rb
+++ b/cookbooks/datadog/recipes/nginx.rb
@@ -1,0 +1,46 @@
+
+NGINX_CHECK = "sudo nginx -V 2>&1 | grep -o with-http_stub_status_module"
+
+if `#{NGINX_CHECK}`.nil? || `#{NGINX_CHECK}`.empty?
+  raise
+end
+
+template "#{node['nginx']['custom']}/custom.txt" do
+  source "custom.txt.erb"
+  owner "root"
+  group "root"
+  mode 00600
+  variables({
+    :internal_ip => node['ec2']['local_ipv4']
+    })
+end
+
+# this might not be applicable for all instances
+bash "cat into custom.conf" do
+  user "root"
+  cwd "#{node['nginx']['custom']}"
+  code "cat custom.txt >> custom.conf "
+  notifies :run, 'execute[nginx-reload]', :immediately
+  not_if {File.readlines("#{node['nginx']['custom']}/custom.conf").grep(/nginx_status/).size > 0}
+end
+
+execute "nginx-reload" do
+  command "nginx -s reload"
+  action :nothing
+end
+
+file "#{node['nginx']['custom']}/custom.txt" do
+  action :delete
+end
+
+
+template "/root/.datadog-agent/agent/conf.d/nginx.yaml" do
+  source "nginx.yaml.erb"
+  owner "root"
+  group "root"
+  mode 00744
+  variables({
+    :env_name => node[:environment][:name],
+    :public_hostname => node["ec2"]["public_hostname"]
+    })
+end

--- a/cookbooks/datadog/templates/default/custom.txt.erb
+++ b/cookbooks/datadog/templates/default/custom.txt.erb
@@ -1,0 +1,8 @@
+
+location /nginx_status {
+   stub_status on;
+
+   access_log off;
+   allow <%= @internal_ip %>;
+   deny all;
+}

--- a/cookbooks/datadog/templates/default/datadog.conf.erb
+++ b/cookbooks/datadog/templates/default/datadog.conf.erb
@@ -1,0 +1,220 @@
+[Main]
+
+# The host of the Datadog intake server to send Agent data to
+dd_url: https://app.datadoghq.com
+
+# If you need a proxy to connect to the Internet, provide the settings here
+# proxy_host: my-proxy.com
+# proxy_port: 3128
+# proxy_user: user
+# proxy_password: password
+# To be used with some proxys that return a 302 which make curl switch from POST to GET
+# See http://stackoverflow.com/questions/8156073/curl-violate-rfc-2616-10-3-2-and-switch-from-post-to-get
+# proxy_forbid_method_switch: no
+
+# If you run the agent behind haproxy, you might want to set this to yes
+# skip_ssl_validation: no
+
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+api_key: <%= @api_key %>
+
+# Force the hostname to whatever you want.
+#hostname: mymachine.mydomain
+
+# Set the host's tags
+tags: role:<%= @role %>, env_name:<%= @env_name %>, hostname:<%= @hostname %>
+
+# Add one "dd_check:checkname" tag per running check. It makes it possible to slice
+# and dice per monitored app (= running Agent Check) on Datadog's backend.
+# create_dd_check_tags: no
+
+# Collect AWS EC2 custom tags as agent tags
+collect_ec2_tags: yes
+
+# Enable Agent Developer Mode
+# Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance
+# developer_mode: no
+# In developer mode, the number of runs to be included in a single collector profile
+# collector_profile_interval: 20
+
+# Collect instance metadata
+# The Agent will try to collect instance metadata for EC2 and GCE instances by
+# trying to connect to the local endpoint: http://169.254.169.254
+# See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
+# and https://developers.google.com/compute/docs/metadata
+# for more information
+collect_instance_metadata: yes
+
+# use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
+gce_updated_hostname: yes
+
+# Set the threshold for accepting points to allow anything
+# with recent_point_threshold seconds
+# Defaults to 30 seconds if no value is provided
+# recent_point_threshold: 30
+
+# Use mount points instead of volumes to track disk and fs metrics
+# DEPRECATED: use conf.d/disk.yaml instead to configure it
+use_mount: no
+
+# Change port the Agent is listening to
+# listen_port: 17123
+
+# Start a graphite listener on this port
+# graphite_listen_port: 17124
+
+# Additional directory to look for Datadog checks
+# additional_checksd: /etc/dd-agent/checks.d/
+
+# Allow non-local traffic to this Agent
+# This is required when using this Agent as a proxy for other Agents
+# that might not have an internet connection
+# For more information, please see
+# https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+# non_local_traffic: no
+
+# Select the Tornado HTTP Client in the forwarder
+# Default to the simple http client
+# use_curl_http_client: False
+
+# The loopback address the Forwarder and Dogstatsd will bind.
+# Optional, it is mainly used when running the agent on Openshift
+# bind_host: localhost
+
+# If enabled the collector will capture a metric for check run times.
+# check_timings: no
+
+# If you want to remove the 'ww' flag from ps catching the arguments of processes
+# for instance for security reasons
+# exclude_process_args: no
+
+# histogram_aggregates: max, median, avg, count
+# histogram_percentiles: 0.95
+
+# ========================================================================== #
+# DogStatsd configuration                                                    #
+# ========================================================================== #
+
+# If you don't want to enable the DogStatsd server, set this option to no
+# use_dogstatsd: yes
+
+# DogStatsd is a small server that aggregates your custom app metrics. For
+# usage information, check out http://api.datadoghq.com
+
+#  Make sure your client is sending to the same port.
+# dogstatsd_port : 8125
+
+# By default dogstatsd will post aggregate metrics to the Agent (which handles
+# errors/timeouts/retries/etc). To send directly to the datadog api, set this
+# to https://app.datadoghq.com.
+# dogstatsd_target : http://localhost:17123
+
+# If you want to forward every packet received by the dogstatsd server
+# to another statsd server, uncomment these lines.
+# WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
+# as your other statsd server might not be able to handle them.
+# statsd_forward_host: address_of_own_statsd_server
+# statsd_forward_port: 8125
+
+# you may want all statsd metrics coming from this host to be namespaced
+# in some way; if so, configure your namespace here. a metric that looks
+# like `metric.name` will instead become `namespace.metric.name`
+# statsd_metric_namespace:
+
+# By default, dogstatsd supports only plain ASCII packets. However, most
+# (dog)statsd client support UTF8 by encoding packets before sending them
+# this option enables UTF8 decoding in case you need it.
+# However, it comes with a performance overhead of ~10% in the dogstatsd
+# server. This will be taken care of properly in the new gen agent core.
+# utf8_decoding: false
+
+# ========================================================================== #
+# Service-specific configuration                                             #
+# ========================================================================== #
+
+# -------------------------------------------------------------------------- #
+#   Disk                                                                     #
+# -------------------------------------------------------------------------- #
+
+# Some infrastrucures have many constantly changing virtual devices (e.g. folks
+# running constantly churning linux containers) whose metrics aren't
+# interesting for datadog. To filter out a particular pattern of devices
+# from collection, configure a regex here:
+# DEPRECATED: use conf.d/disk.yaml instead to configure it
+# device_blacklist_re: .*\/dev\/mapper\/lxc-box.*
+
+# -------------------------------------------------------------------------- #
+#   Ganglia                                                                  #
+# -------------------------------------------------------------------------- #
+
+# Ganglia host where gmetad is running
+#ganglia_host: localhost
+
+# Ganglia port where gmetad is running
+#ganglia_port: 8651
+
+# -------------------------------------------------------------------------- #
+#  Dogstream (log file parser)
+# -------------------------------------------------------------------------- #
+
+# Comma-separated list of logs to parse and optionally custom parsers to use.
+# The form should look like this:
+#
+#   dogstreams: /path/to/log1:parsers_module:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Or this:
+#
+#   dogstreams: /path/to/log1:/path/to/my/parsers_module.py:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Each entry is a path to a log file and optionally a Python module/function pair
+# separated by colons.
+#
+# Custom parsers should take a 2 parameters, a logger object and
+# a string parameter of the current line to parse. It should return a tuple of
+# the form:
+#   (metric (str), timestamp (unix timestamp), value (float), attributes (dict))
+# where attributes should at least contain the key 'metric_type', specifying
+# whether the given metric is a 'counter' or 'gauge'.
+#
+# Unless parsers are specified with an absolute path, the modules must exist in
+# the Agent's PYTHONPATH. You can set this as an environment variable when
+# starting the Agent. If the name of the custom parser function is not passed,
+# 'parser' is assumed.
+#
+# If this value isn't specified, the default parser assumes this log format:
+#     metric timestamp value key0=val0 key1=val1 ...
+#
+
+# ========================================================================== #
+# Custom Emitters                                                            #
+# ========================================================================== #
+
+# Comma-separated list of emitters to be used in addition to the standard one
+#
+# Expected to be passed as a comma-separated list of colon-delimited
+# name/object pairs.
+#
+# custom_emitters: /usr/local/my-code/emitters/rabbitmq.py:RabbitMQEmitter
+#
+# If the name of the emitter function is not specified, 'emitter' is assumed.
+
+
+# ========================================================================== #
+# Logging
+# ========================================================================== #
+
+# log_level: INFO
+
+# collector_log_file: /var/log/datadog/collector.log
+# forwarder_log_file: /var/log/datadog/forwarder.log
+# dogstatsd_log_file: /var/log/datadog/dogstatsd.log
+
+# if syslog is enabled but a host and port are not set, a local domain socket
+# connection will be attempted
+#
+# log_to_syslog: yes
+# syslog_host:
+# syslog_port:
+disable_file_logging: Truedisable_file_logging: True

--- a/cookbooks/datadog/templates/default/nginx.yaml.erb
+++ b/cookbooks/datadog/templates/default/nginx.yaml.erb
@@ -1,0 +1,9 @@
+init_config:
+
+instances:
+    # For every instance, you have an `nginx_status_url` and (optionally)
+    # a list of tags.
+
+    -   nginx_status_url: http://<%= @public_hostname %>/nginx_status
+        tags:
+            -   env_name:<%= @env_name %>


### PR DESCRIPTION
# What? Why?
This recipe adds support for datadog and the nginx integration on EY.

Would love some feedback

# How was it tested?
Running 3 Ruby on Rails Solo EY instances


# Requirements
#### Get It Working
You need to add your datadog api key to the `attributes/default.rb` 
`default['datadog']['api_key'] = "" `

If not already included, add:
`include_recipe 'datadog` to the main recipes folder

#### FOR NGINX SUPPORT:
1. remove the comments in `recipes/default.rb` 
2. You need to add the directory where your custom nginx files are, to the `attributes/default.rb` 
3. add the nginx integration in the datadog control panel.
