### PR TITLE
Minor bugfix on redis recipe

### DIFF
--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -80,7 +80,7 @@ end
 
 if ['solo', 'app', 'app_master', 'util'].include?(node[:instance_role])
   instances = node[:engineyard][:environment][:instances]
-  redis_instance = (node[:instance_role][/solo/] && instances.length == 1) ? instances[0] : instances.find{|i| i[:name].to_s[/redis/]}
+  redis_instance = (node[:instance_role][/solo/] && instances.length == 1) ? instances[0] : instances.find{|i| "redis" == i[:name]}
 
   if redis_instance
     ip_address = `ping -c 1 #{redis_instance[:private_hostname]} | awk 'NR==1{gsub(/\\(|\\)/,"",$3); print $3}'`.chomp


### PR DESCRIPTION
redis_instance should be the first instance named "redis", not the first instance with a name that matches /redis/.

For environments with a redis_backup or redis_slave instance, the match check might pick up these instances instead.