### PR TITLE
Fix redis-yml instructions

### DIFF
--- a/cookbooks/redis-yml/README.md
+++ b/cookbooks/redis-yml/README.md
@@ -8,7 +8,7 @@ Overview
 
 Redis.yml will help you connect to Redis on the utility instance from your Rails application
 
-Currently in the default.rb file under Recipes you utility instance is specified based on the first one it finds, if you have multiple utility instances you can specify it by removing "node['utility_instances'].first" and replace it with the commented out code. You can change the name of the instance based on whatever name you have chosen for your instance.
+First, you have to modify the `recipes/default.rb`. Make sure where is the Redis server running on and set the `redis_instance`.
 
 [1]: http://redis.io/
 [2]: http://redis.io/topics/data-types#sorted-sets

--- a/cookbooks/redis-yml/recipes/default.rb
+++ b/cookbooks/redis-yml/recipes/default.rb
@@ -1,11 +1,11 @@
 if ['app_master', 'app', 'solo', 'util'].include?(node[:instance_role])
 
   # If you have only one utility instance uncomment the line below
-  #redis_instance = node['utility_instances'].first
+  #redis_instance = node.engineyard.environment.instances.find { |instance| instance[:role] == 'util' }
   # Otherwise, if you have multiple utility instances you can specify it by uncommenting the line below
   # You can change the name of the instance based on whatever name you have chosen for your instance.
-  #redis_instance = node['utility_instances'].find { |instance| instance['name'] == 'redis' }
-  
+  #redis_instance = node.engineyard.environment.instances.find { |instance| instance[:name] == 'redis' }
+
   if redis_instance
     node[:applications].each do |app, data|
       template "/data/#{app}/shared/config/redis.yml"do


### PR DESCRIPTION
I noticed `node['utility_instances']` doesn't have `hostname`. This is a fix for that.