### PR TITLE
Remove --oknodo from LE recipe.

### DIFF
--- a/cookbooks/le/templates/default/logentries.initd.erb
+++ b/cookbooks/le/templates/default/logentries.initd.erb
@@ -12,12 +12,12 @@ depend() {
 
 start() {
 	ebegin "Starting Logentries Agent"
-	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --exec $EXEC
-	eend $? 
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $EXEC
+	eend $?
 }
 
 stop() {
 	ebegin "Stopping Logentries Agent"
-	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+	start-stop-daemon --stop --quiet --pidfile $PIDFILE
 	eend $?
 }


### PR DESCRIPTION
--oknodo params is deprecated and crashed logentries when stop application.

```
$ sudo /etc/init.d/logentries stop
 * Stopping Logentries Agent ...
 * WARNING: -o/--oknodo is deprecated and will be removed in the future
 * start-stop-daemon: no matching processes found                                                                                                                                                                                                                         [ !! ]
 * ERROR: logentries failed to stop
```

I removed and my instances are green.