### PR TITLE
Add the rails-secrets recipe

### DIFF
--- a/cookbooks/api-keys-yml/README.md
+++ b/cookbooks/api-keys-yml/README.md
@@ -1,7 +1,9 @@
+NOTE: Rails 4.1 introduced [secrets.yml](http://guides.rubyonrails.org/4_1_release_notes.html#config-secrets-yml). If your application is built on Rails 4.1 or later, please use the [rails-secrets](https://github.com/engineyard/ey-cloud-recipes/tree/master/cookbooks/rails-secrets) recipe instead. That recipe includes instructions specific to the Rails secrets file.
+
 Don't want to check API keys into version control? No problem!
 --------------------------------------------------------------
 
-This Chef recipe will write api-keys.yml to your Rails app's config/ directory on Engine Yard Cloud.
+This Chef recipe will write api-keys.yml to your app's config/ directory on Engine Yard Cloud.
 
 # Instructions:
 

--- a/cookbooks/rails-secrets/README.md
+++ b/cookbooks/rails-secrets/README.md
@@ -1,0 +1,14 @@
+Don't want to check API keys into version control? No problem!
+--------------------------------------------------------------
+
+This Chef recipe will write `secrets.yml` to `/data/<app_name>/shared/config`. During deployment, `secrets.yml` will be symlinked to `/data/<app_name>/current/config`. The end result is you'll have your production `secrets.yml` into your Rails application's `config/` directory.
+
+# Instructions:
+
+1. Populate the templates/default/secrets.yml.erb with your production-ready API keys.
+2. Be sure to uncomment `include_recipe "rails-secrets"` from `cookbooks/main/default/recipes.rb` per usual.
+3. That's it! Upload (`ey recipes upload -e [env]`) and apply (`ey recipes apply -e [env]`)
+
+# Tips:
+
+You usually want to maintain two version control repositories: one for the application source code and one for the infrastructure source code. The production API keys along with these chef recipes belong to the infrastructure source code.

--- a/cookbooks/rails-secrets/recipes/default.rb
+++ b/cookbooks/rails-secrets/recipes/default.rb
@@ -1,0 +1,11 @@
+if ['app_master', 'app', 'util', 'solo'].include?(node[:instance_role])
+  node[:applications].each do |app, data|
+    template "/data/#{app}/shared/config/secrets.yml"do
+      source 'secrets.yml.erb'
+      owner node[:owner_name]
+      group node[:owner_name]
+      mode 0655
+      backup 0
+    end
+  end
+end

--- a/cookbooks/rails-secrets/templates/default/secrets.yml.erb
+++ b/cookbooks/rails-secrets/templates/default/secrets.yml.erb
@@ -1,0 +1,1 @@
+## Put your API tokens here!


### PR DESCRIPTION
Rails 4.1 introduced secrets.yml which does part of what api-keys-yml is meant for. rails-secrets is a simplified version of api-keys-yml and includes instructions specific to Rails applications.

api-keys-yml is still useful for non-Rails or pre-Rails 4.1 applications.

This PR also includes a pointer from api-keys-yml's README to the rails-secrets recipe.