### PR TITLE
Add the imagemagick cookbook to address recent vulnerabilities

### DIFF
--- a/cookbooks/imagemagick/README.md
+++ b/cookbooks/imagemagick/README.md
@@ -1,0 +1,21 @@
+ImageMagick Cookbook
+=========
+
+There were two recent ImageMagick-related vulnerabilities:
+
+* CVE-2016-5118
+* CVE-2016-3714
+
+This cookbook installs ImageMagick 6.9.0.3-r1 (available on the latest Gentoo 12.11 stack) and a policy.xml file. 
+
+The 6.9.0.3-r1 ebuild includes backported patches to address the popen vulnerability in CVE-2016-5118.
+
+The policy.xml file is the policy recommended in https://www.imagemagick.org/discourse-server/viewtopic.php?f=4&p=132726&sid=6b961f8b680a0c18189de528bd53504a#p132726 to address CVE-2016-3714.
+
+To use this recipe, add the line
+
+```
+include_recipe 'imagemagick'
+```
+
+to `cookbooks/main/recipes/default.rb`.

--- a/cookbooks/imagemagick/files/default/imagemagickkeywords
+++ b/cookbooks/imagemagick/files/default/imagemagickkeywords
@@ -1,0 +1,3 @@
+=media-gfx/imagemagick-6.9.0.3
+=media-libs/lcms-2.3
+

--- a/cookbooks/imagemagick/files/default/imagemagickunmask
+++ b/cookbooks/imagemagick/files/default/imagemagickunmask
@@ -1,0 +1,3 @@
+=media-gfx/imagemagick-6.9.0.3
+=media-libs/lcms-2.3
+

--- a/cookbooks/imagemagick/files/default/policy.xml
+++ b/cookbooks/imagemagick/files/default/policy.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+  
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, width, height, and disk resources
+  with SI prefixes (.e.g 100MB).  In addition, resource policies are maximums
+  for each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <!-- <policy domain="resource" name="memory" value="2GiB"/> -->
+  <!-- <policy domain="resource" name="map" value="4GiB"/> -->
+  <!-- <policy domain="resource" name="width" value="100MP"/> -->
+  <!-- <policy domain="resource" name="height" value="100MP"/> -->
+  <!-- <policy domain="resource" name="area" value="1GB"/> -->
+  <!-- <policy domain="resource" name="disk" value="16EB"/> -->
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <policy domain="cache" name="shared-secret" value="passphrase"/>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+  <policy domain="path" rights="none" pattern="@*" />
+
+</policymap>
+

--- a/cookbooks/imagemagick/recipes/default.rb
+++ b/cookbooks/imagemagick/recipes/default.rb
@@ -1,0 +1,54 @@
+#Update imagemagick and install policy patch
+
+ey_cloud_report "imagemagick-install" do
+  message "Installing php imagemagick security update}"
+end
+
+
+portage_files = [
+  "/etc/portage/package.keywords/imagemagickkeywords",
+  "/etc/portage/package.unmask/imagemagickunmask"
+]
+
+portage_files.each do |portage_file|
+  remote_file portage_file do
+    source File.basename(portage_file)
+    backup 0
+    owner "portage"
+    group "portage"
+    mode 0644
+  end
+end
+
+if Chef::VERSION == '10.34.6'
+  enable_package "media-libs/openjpeg" do
+    version "2.1.0"
+  end
+  package "media-libs/openjpeg" do
+    version "2.1.0"
+    action :install
+  end
+end
+
+
+enable_package "media-libs/lcms" do
+  version "2.3"
+end
+
+
+enable_package "media-gfx/imagemagick" do
+  version "6.9.0.3-r1"
+end
+
+package "media-gfx/imagemagick" do
+  version "6.9.0.3-r1"
+  action :install
+end
+
+remote_file "/etc/ImageMagick-6/policy.xml" do
+  source "policy.xml"
+  owner "root"
+  group "root"
+  mode 0644
+  backup 0
+end


### PR DESCRIPTION
This is to address CVE-2016-5118 and CVE-2016-3714

czimmerman's imagemagick branch fell behind master and merging that will result in too many changes. I cherry-picked the changes from that branch and added a README to create this PR.