### PR TITLE
fix readme setup instructions

### DIFF
--- a/cookbooks/delayed_job4/README.markdown
+++ b/cookbooks/delayed_job4/README.markdown
@@ -10,7 +10,7 @@ vary based on the size of the instance running Delayed Job.
 
 To install this, you will need to add the following to cookbooks/main/recipes/default.rb:
 
-    include_recipe "delayed_job"
+    include_recipe "delayed_job4"
 
 Make sure this and any customizations to the recipe are committed to your own fork of this
 repository.


### PR DESCRIPTION
users should include delayed_job4, not delayed_job, in main recipes.