### PR TITLE
Run datadog as the deploy user

### DIFF
--- a/cookbooks/datadog/files/default/datadog.monitrc
+++ b/cookbooks/datadog/files/default/datadog.monitrc
@@ -1,5 +1,5 @@
 check process datadog_wrapper
-  with pidfile /var/run/datadog_wrapper.pid
-  start program = "/bin/datadog_wrapper start"
-  stop program = "/bin/datadog_wrapper stop"
+  with pidfile /home/deploy/datadog/.datadog-agent/run/datadog_wrapper.pid
+  start program = "/bin/datadog_wrapper start" as uid deploy gid deploy
+  stop program = "/bin/datadog_wrapper stop" as uid deploy gid deploy
   group datadog

--- a/cookbooks/datadog/files/default/datadog_wrapper.sh
+++ b/cookbooks/datadog/files/default/datadog_wrapper.sh
@@ -2,12 +2,12 @@
 
 case $1 in
   start)
-     echo $$ > /var/run/datadog_wrapper.pid
-     /bin/bash /root/.datadog-agent/bin/agent start
+     echo $$ > /home/deploy/datadog/.datadog-agent/run/datadog_wrapper.pid
+     /bin/bash /home/deploy/datadog/.datadog-agent/bin/agent start
      ;;
    stop)
-     kill `cat /var/run/datadog_wrapper.pid`
-     kill `cat /root/.datadog-agent/run/supervisord.pid`
+     kill `cat /home/deploy/datadog/.datadog-agent/run/datadog_wrapper.pid`
+     kill `cat /home/deploy/datadog/.datadog-agent/run/supervisord.pid`
      ;;
    *)
      echo "usage: datadog_wrapper {start|stop}" ;;

--- a/cookbooks/datadog/files/default/setup_agent.sh
+++ b/cookbooks/datadog/files/default/setup_agent.sh
@@ -198,15 +198,7 @@ else
 fi
 
 # create home base for the Agent
-if [ $dd_home ]; then
-  dd_base=$dd_home
-else
-  if [ "$unamestr" = "SunOS" ]; then
-      dd_base="/opt/local/datadog"
-  else
-      dd_base=$HOME/.datadog-agent
-  fi
-fi
+dd_base=/home/deploy/datadog/.datadog-agent
 
 
 printf "Creating Agent directory $dd_base....."

--- a/cookbooks/datadog/files/default/setup_agent.sh
+++ b/cookbooks/datadog/files/default/setup_agent.sh
@@ -10,6 +10,12 @@
 #                                                  #
 #        ALEX - EZCATER, INC - @alexmoreale        #
 ####################################################
+# Reference script: https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh
+# Modified by Engine Yard Support
+#
+# Changes:
+# - run datadog and supervisor as the deploy user instead of root
+# - disable installation of optional packages
 
 # figure out where to pull from
 tag="5.6.3"
@@ -241,14 +247,17 @@ $dd_base/venv/bin/pip install -r $dd_base/requirements.txt >> $logfile 2>&1
 rm $dd_base/requirements.txt
 print_done
 
-printf "Trying to install optional dependencies using pip....." | tee -a $logfile
-$dl_cmd $dd_base/requirements.txt https://raw.githubusercontent.com/DataDog/dd-agent/$tag/requirements-opt.txt  >> $logfile 2>&1
-while read DEPENDENCY
-do
-    ($dd_base/venv/bin/pip install $DEPENDENCY || printf "Cannot install $DEPENDENCY. There is probably no Compiler on the system.") >> $logfile 2>&1
-done < $dd_base/requirements.txt
-rm $dd_base/requirements.txt
-print_done
+# Skip the step to install optional dependencies
+# Some of these modules are for Windows and so are irrelevant anyway
+# And many require compilation with native modules
+#printf "Trying to install optional dependencies using pip....." | tee -a $logfile
+#$dl_cmd $dd_base/requirements.txt https://raw.githubusercontent.com/DataDog/dd-agent/$tag/requirements-opt.txt  >> $logfile 2>&1
+#while read DEPENDENCY
+#do
+#    ($dd_base/venv/bin/pip install $DEPENDENCY || printf "Cannot install $DEPENDENCY. There is probably no Compiler on the system.") >> $logfile 2>&1
+#done < $dd_base/requirements.txt
+#rm $dd_base/requirements.txt
+#print_done
 
 # set up the Agent
 mkdir -p $dd_base/agent >> $logfile 2>&1

--- a/cookbooks/datadog/files/default/supervisord.conf
+++ b/cookbooks/datadog/files/default/supervisord.conf
@@ -1,0 +1,51 @@
+[supervisord]
+logfile = /data/datadog/supervisor/logs/supervisord.log
+logfile_maxbytes = 50MB
+loglevel = info
+nodaemon = true
+identifier = supervisor
+nocleanup = true
+pidfile = /data/datadog/run/supervisord.pid
+user = nobody
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file = /data/datadog/run/agent-supervisor.sock
+
+[supervisorctl]
+prompt = datadog
+serverurl = unix:///data/datadog/run/agent-supervisor.sock
+
+[program:collector]
+command=python agent/agent.py foreground --use-local-forwarder
+stdout_logfile=/data/datadog/supervisor/logs/collector.log
+redirect_stderr=true
+priority=999
+startsecs=2
+environment=LANG=POSIX,PYTHONPATH='agent/checks/libs:$PYTHONPATH'
+
+[program:forwarder]
+command=python agent/ddagent.py --use_simple_http_client=1
+stdout_logfile=/data/datadog/supervisor/logs/forwarder.log
+redirect_stderr=true
+priority=998
+startsecs=3
+
+[program:dogstatsd]
+command=python agent/dogstatsd.py --use-local-forwarder
+stdout_logfile=/data/datadog/supervisor/logs/dogstatsd.log
+redirect_stderr=true
+priority=998
+startsecs=3
+
+[program:jmxfetch]
+command=python agent/jmxfetch.py
+stdout_logfile=/data/datadog/supervisor/logs/jmxfetch.log
+redirect_stderr=true
+priority=999
+startsecs=3
+
+[group:datadog-agent]
+programs=forwarder,collector,dogstatsd,jmxfetch

--- a/cookbooks/datadog/recipes/config.rb
+++ b/cookbooks/datadog/recipes/config.rb
@@ -2,10 +2,10 @@ ey_cloud_report "datadog" do
  message "DataDog::Custom Config Start"
 end
 
-template '/root/.datadog-agent/agent/datadog.conf' do
+template '/home/deploy/datadog/.datadog-agent/agent/datadog.conf' do
   source 'datadog.conf.erb'
-  owner 'root'
-  group 'root'
+  owner 'deploy'
+  group 'deploy'
   mode '640'
   variables({
     :hostname => node[:hostname],

--- a/cookbooks/datadog/recipes/daemonize.rb
+++ b/cookbooks/datadog/recipes/daemonize.rb
@@ -8,14 +8,14 @@ end
 cookbook_file "copy in the wrapper script" do
 	path "#{node['wrapper']['directory']}/datadog_wrapper.sh"
   source "datadog_wrapper.sh"
-  owner "root"
-  group "root"
+  owner "deploy"
+  group "deploy"
   mode "744"
   not_if "test -f #{node['wrapper']['directory']}/datadog_wrapper.sh"
 end
 
 link "dd-link" do
-  owner "root"
+  owner "deploy"
   target_file "/bin/datadog_wrapper"
 	to "#{node['wrapper']['directory']}/datadog_wrapper.sh"
 end
@@ -28,8 +28,8 @@ end
 cookbook_file "copy in the datadog monit" do
 	path "#{node['monit']['directory']}/datadog.monitrc"
   source "datadog.monitrc"
-  owner "root"
-  group "root"
+  owner "deploy"
+  group "deploy"
   mode "644"
 	not_if "test -f #{node['monit']['directory']}/datadog.monitrc"
   notifies :run, 'execute[monit-reload]', :immediately

--- a/cookbooks/datadog/recipes/default.rb
+++ b/cookbooks/datadog/recipes/default.rb
@@ -10,7 +10,7 @@
 
 
 execute "monit-stop-dd" do
- user "root"
+ user "deploy"
  cwd "/"
  command "monit stop datadog_wrapper; sleep 30"
  only_if " pgrep 'datadog_wrapper' > /dev/null"

--- a/cookbooks/datadog/recipes/finish.rb
+++ b/cookbooks/datadog/recipes/finish.rb
@@ -1,6 +1,6 @@
 
 execute "monit-start-dd" do
- user "root"
+ user "deploy"
  command "monit start datadog_wrapper"
  only_if " pgrep 'datadog_wrapper' < /dev/null"
 end

--- a/cookbooks/datadog/recipes/finish.rb
+++ b/cookbooks/datadog/recipes/finish.rb
@@ -1,6 +1,4 @@
-
 execute "monit-start-dd" do
- user "deploy"
  command "monit start datadog_wrapper"
  only_if " pgrep 'datadog_wrapper' < /dev/null"
 end

--- a/cookbooks/datadog/recipes/install.rb
+++ b/cookbooks/datadog/recipes/install.rb
@@ -6,29 +6,36 @@ ey_cloud_report "datadog" do
  message "DataDog::Install Start"
 end
 
+directory '/home/deploy/datadog' do
+  owner 'deploy'
+  group 'deploy'
+  mode 0755
+  action :create
+end
+
 cookbook_file 'copy in setup script' do
-	path '/root/setup_agent.sh'
+  path '/home/deploy/datadog/setup_agent.sh'
   source 'setup_agent.sh'
-  owner 'root'
-  group 'root'
+  owner 'deploy'
+  group 'deploy'
   mode '744'
-	not_if { File.exists?( '/root/setup_agent.sh')  }
+  not_if { File.exists?( '/home/deploy/datadog/setup_agent.sh')  }
 end
 
 bash 'run the setup script' do
- user 'root'
- cwd '/root'
+ user 'deploy'
+ cwd '/home/deploy/datadog'
  code <<-EOH
   DD_API_KEY=#{node['datadog']['api_key']} sh ./setup_agent.sh
-	EOH
+  EOH
  notifies :run, 'execute[rm-setup-tools]', :immediately
- not_if "test -f /root/.datadog-agent/bin/agent"
+ not_if "test -f /home/deploy/datadog/.datadog-agent/bin/agent"
 end
 
 execute 'rm-setup-tools' do
- command "find /root -name 'setuptools-*.zip' | xargs rm"
- action :nothing
- only_if { !Dir.glob('/root/setuptools*.zip').empty? }
+  command "find /home/deploy/datadog -name 'setuptools-*.zip' | xargs rm"
+  action :nothing
+   only_if { !Dir.glob('/home/deploy/datadog/setuptools*.zip').empty? }
 end
 
 ey_cloud_report "datadog" do

--- a/cookbooks/datadog/recipes/postgres.rb
+++ b/cookbooks/datadog/recipes/postgres.rb
@@ -14,10 +14,10 @@ if ['solo', 'db_master', 'db_slave'].include?(node[:instance_role])
     not_if %{psql -U postgres postgres -c "SELECT has_table_privilege('datadog', 'pg_stat_database', 'SELECT')" | grep "t"}
   end
 
-  template '/root/.datadog-agent/agent/conf.d/postgres.yaml' do
+  template '/home/deploy/datadog/.datadog-agent/agent/conf.d/postgres.yaml' do
     source 'postgres.yaml.erb'
-    owner 'root'
-    group 'root'
+    owner 'deploy'
+    group 'deploy'
     mode 00764
     variables({
       :dd_pg_user => node["postgres"]["dd-user"],


### PR DESCRIPTION
This addresses item #1 in https://github.com/engineyard/ey-cloud-recipes/issues/279

Changes:
* Installs datadog to `/home/deploy/datadog` instead of `/root/datadog`
* Runs datadog and supervisor as the deploy user instead of the root user