### PR TITLE
Modify Redis recipe to install from source

### DIFF
--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -46,6 +46,11 @@ Add the following to your main/recipes/default.rb
 
 ``include_recipe "redis"``
 
+Upgrading from a previous Redis version
+---
+
+Before upgrading, please review the Redis release notes for the version you're upgrading to, to ensure compatibility with your current Redis data. After upgrading, Redis server will be installed to `/usr/local/bin/redis-server`. However, the old version of Redis will still be running. Please run `sudo monit restart redis-1` to restart Redis.
+
 Choosing a different Redis version
 --------
 This recipe installs Redis 2.8.13-r1 by default. We do not recommend earlier versions of Redis 2.8.x or 2.6.x as these versions have a known vulnerability: http://benmmurphy.github.io/blog/2015/06/04/redis-eval-lua-sandbox-escape/

--- a/cookbooks/redis/templates/default/redis.monitrc.erb
+++ b/cookbooks/redis/templates/default/redis.monitrc.erb
@@ -1,5 +1,5 @@
 check process redis-<%= @profile %>
 with pidfile <%= @pidfile %>
-  start program = "<%= @bin_path %> <%= @configfile %>"
-  stop program = "/usr/bin/redis-cli -p <%= @port %> shutdown"
+  start program = "<%= @bin_path %>/redis-server <%= @configfile %>"
+  stop program = "<%= @bin_path %>/redis-cli -p <%= @port %> shutdown"
   group redis-util


### PR DESCRIPTION
This will let V4 customers run Redis 3.2.3 which supports clustering

The PR _does not_ include changes to support clustering.