### PR TITLE
Adding Classiclink cookbook

### DIFF
--- a/cookbooks/classiclink/README.md
+++ b/cookbooks/classiclink/README.md
@@ -1,0 +1,19 @@
+##EC2 Classic to VPC Classiclinking
+
+This recipe is for use by Engine Yard customers whose accounts run under EC2 Classic but require VPC Peering. Engine Yard Support can create a VPC for peering purposes, after which Engine Yard provisioned EC2 instances can be [Classiclinked] (https://aws.amazon.com/blogs/aws/classiclink-private-communication-between-classic-ec2-instances-vpc-resources/) to this VPC. This recipe automates Classiclinking for all instances in the relevant environment.
+
+###Prerequisites
+
+1. Engine Yard Support must create a VPC under the customer's existing EY AWS account, then initiate and configure peering. Please [open a ticket with Support] (https://support.cloud.engineyard.com) to arrange this.
+2. Support must create an IAM user with an inline policy, granting permissions only for `ec2:AttachClassicLinkVpc`.
+3. Support must add metadata entries at the Account level for the IAM user's ID and secret key, with values `classiclink_iam_id` and `classiclink_iam_key`.
+4. Support must add metadata entries at the Environment level for the VPC and VPC's default security group that the environment's instances should be Classiclinked to, with values `classiclink_vpc_id` and `classiclink_security_group_id`.
+
+###Running
+
+- The recipe then requires no configuration by the customer, it simple needs enabling in the `/cookbooks/main/recipes/default.rb` file.
+
+###Notes
+
+- An instance can only ever be linked to one VPC.
+- If you require instances to be unlinked please request this from EY Support. If you require some instances in an environment to be linked and some not then the recipe will need to be updated to handle this.

--- a/cookbooks/classiclink/attributes/classiclink.rb
+++ b/cookbooks/classiclink/attributes/classiclink.rb
@@ -1,0 +1,4 @@
+if environment_metadata = node[:engineyard][:environment][:components].find{|c| c['key'] == 'environment_metadata'}
+  default[:classiclink_vpc_id]            = environment_metadata['classiclink_vpc_id']
+  default[:classiclink_security_group_id] = environment_metadata['classiclink_security_group_id']
+end

--- a/cookbooks/classiclink/attributes/credentials.rb
+++ b/cookbooks/classiclink/attributes/credentials.rb
@@ -1,0 +1,4 @@
+if environment_metadata = node[:engineyard][:environment][:components].find{|c| c['key'] == 'environment_metadata'}
+  default[:classiclink_iam_id]  = environment_metadata['classiclink_iam_id']
+  default[:classiclink_iam_key] = environment_metadata['classiclink_iam_key']
+end

--- a/cookbooks/classiclink/recipes/classiclink.rb
+++ b/cookbooks/classiclink/recipes/classiclink.rb
@@ -3,11 +3,7 @@
 # Recipe:: classiclink
 #
 
-if solo? || app_master?
-  node[:engineyard][:environment][:instances].each do |i|
-    id = i.first[1]
-    bash "attach-classiclink-for-#{id}" do
-      code "aws ec2 attach-classic-link-vpc --instance-id #{id} --vpc-id #{node[:classiclink_vpc_id]} --groups #{node[:classiclink_security_group_id]}"
-    end
-  end
+id = node[:engineyard][:this]
+bash "attach-classiclink-for-#{id}" do
+  code "aws ec2 attach-classic-link-vpc --instance-id #{id} --vpc-id #{node[:classiclink_vpc_id]} --groups #{node[:classiclink_security_group_id]}"
 end

--- a/cookbooks/classiclink/recipes/classiclink.rb
+++ b/cookbooks/classiclink/recipes/classiclink.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: classiclink
+# Recipe:: classiclink
+#
+
+if solo? || app_master?
+  node[:engineyard][:environment][:instances].each do |i|
+    id = i.first[1]
+    bash "attach-classiclink-for-#{id}" do
+      code "aws ec2 attach-classic-link-vpc --instance-id #{id} --vpc-id #{node[:classiclink_vpc_id]} --groups #{node[:classiclink_security_group_id]}"
+    end
+  end
+end

--- a/cookbooks/classiclink/recipes/default.rb
+++ b/cookbooks/classiclink/recipes/default.rb
@@ -1,0 +1,7 @@
+#
+# Cookbook Name:: classiclink
+# Recipe:: default
+#
+
+include_recipe "classiclink::install"
+include_recipe "classiclink::classiclink"

--- a/cookbooks/classiclink/recipes/install.rb
+++ b/cookbooks/classiclink/recipes/install.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: classiclink
+# Recipe:: install
+#
+
+remote_file "/tmp/awscli-bundle.zip" do
+  source "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
+  owner "root"
+  group "root"
+  mode "0644"
+end
+
+bash "install-aws-cli" do
+  code "cd /tmp && rm -rf /tmp/awscli-bundle && unzip -o /tmp/awscli-bundle.zip && rm -rf /usr/local/aws && /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && rm /tmp/awscli-bundle.zip"
+end
+
+directory "/root/.aws/" do
+  owner "root"
+  group "root"
+  mode 0755
+  action :create
+  recursive true
+end
+
+template "/root/.aws/config" do
+  source "aws.config.erb"
+  owner "root"
+  group "root"
+  mode 0755
+end
+
+template "/root/.aws/credentials" do
+  source "aws.credentials.erb"
+  owner "root"
+  group "root"
+  mode 0755
+end

--- a/cookbooks/classiclink/templates/default/aws.config.erb
+++ b/cookbooks/classiclink/templates/default/aws.config.erb
@@ -1,0 +1,2 @@
+[default]
+region = <%= @node[:engineyard][:environment][:region] %>

--- a/cookbooks/classiclink/templates/default/aws.credentials.erb
+++ b/cookbooks/classiclink/templates/default/aws.credentials.erb
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = <%= @node[:classiclink_iam_id] %>
+aws_secret_access_key = <%= @node[:classiclink_iam_key] %>

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -189,3 +189,6 @@
 
 #unncomment to install clamav
 #include_recipe "clamav"
+
+#uncomment to include the classiclink recipe
+#include_recipe "classiclink"


### PR DESCRIPTION
Adds cookbook to automate Classiclinking of EC2 Classic instances to manually created VPCs for peering purposes.