### PR TITLE
Disable protected-mode

### DIFF
--- a/cookbooks/redis/templates/default/redis-3.2.conf.erb
+++ b/cookbooks/redis/templates/default/redis-3.2.conf.erb
@@ -941,3 +941,5 @@ hz <%= @hz %>
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
+
+protected-mode no


### PR DESCRIPTION
Allow customers to shoot themselves in the foot.  This basically reverts
the default behavior of redis 2.8 and other lower versions of Redis.