### PR TITLE
adding aws installation lines to cookbooks/main/recipes/default.rb

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -7,6 +7,9 @@
 #  }
 #end
 
+#uncomment to install aws-cli tools
+#include_recipe "aws_cli"
+
 # uncomment to deny access to /log, /config, and .git directories as well as any .yml files
 # include_recipe "deny-directories"
 


### PR DESCRIPTION
default.rb lacked the aws_cli install lines
