### PR TITLE
Generate keep files for shared databases

### DIFF
--- a/cookbooks/shared_db/recipes/default.rb
+++ b/cookbooks/shared_db/recipes/default.rb
@@ -15,6 +15,12 @@ parent_app_path = "/data/#{parent_app}/shared/config/database.yml"
 
 if apps && parent_app
   for app in apps
+	      file "/data/#{app}/shared/config/keep.database.yml" do
+      			owner 'root'
+      			group 'root'
+      			mode '0755'
+      			action :create
+    		end
 		execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
 			command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
 			only_if "test -f #{parent_app_path}"


### PR DESCRIPTION
fixes #308 where parent database credentials would be overwritten by a child's.