### PR TITLE
Cc 439

### DIFF
--- a/cookbooks/eybackup_slave/attributes/default.rb
+++ b/cookbooks/eybackup_slave/attributes/default.rb
@@ -1,4 +1,6 @@
 # are the backups encrypted
 components = node[:engineyard][:environment][:apps].map {|a| a[:components]}.flatten
 default[:encrypted_backups] = components.map {|c| c[:key]}.include?('encrypted_backup')
-default[:public_key] = default[:encrypted_backups] ? components.find {|c| c[:public_key]}[:public_key] : nil
+if default[:encrypted_backups]
+  default[:public_key] = components.find {|c| c[:public_key]}[:public_key]
+end

--- a/cookbooks/eybackup_slave/recipes/default.rb
+++ b/cookbooks/eybackup_slave/recipes/default.rb
@@ -27,12 +27,8 @@ if db_slave
 
     # check for encryption
     if node[:encrypted_backups]
-      # gnupg package - install on stable-v2 but not stable-v4, this version does not exist on v4 and gnupg is already installed by default
-      if Chef::VERSION[/^0.6/]
-        package "app-crypt/gnupg" do
-          version '2.0.9'
-          action :install
-        end
+      package "app-crypt/gnupg" do
+        action :install
       end
 
       # public key

--- a/cookbooks/eybackup_slave/recipes/default.rb
+++ b/cookbooks/eybackup_slave/recipes/default.rb
@@ -27,10 +27,12 @@ if db_slave
 
     # check for encryption
     if node[:encrypted_backups]
-      # gnupg package
-      package "app-crypt/gnupg" do
-        version '2.0.9'
-        action :install
+      # gnupg package - install on stable-v2 but not stable-v4, this version does not exist on v4 and gnupg is already installed by default
+      if Chef::VERSION[/^0.6/]
+        package "app-crypt/gnupg" do
+          version '2.0.9'
+          action :install
+        end
       end
 
       # public key

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -38,7 +38,7 @@
 #include_recipe "authorized_keys"
 
 #uncomment to run the eybackup_slave recipe
- include_recipe "eybackup_slave"
+# include_recipe "eybackup_slave"
 
 #uncomment to run the ssmtp recipe
 #include_recipe "ssmtp"

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -38,7 +38,7 @@
 #include_recipe "authorized_keys"
 
 #uncomment to run the eybackup_slave recipe
-# include_recipe "eybackup_slave"
+ include_recipe "eybackup_slave"
 
 #uncomment to run the ssmtp recipe
 #include_recipe "ssmtp"


### PR DESCRIPTION
## Description of your patch

This patch fixes eybackup_slave on stable-v4 and Chef10.  
## Estimated risk

low
## Components involved

mysql
postgres
eybackup
## Description of testing done

tested on solo and clustered environments both with encrypted backups don't on and off
## QA Instructions

Uncomment the include_recipe for eybackup_slave, upload and apply to environment with db_slave
