### PR TITLE
Fixes db_client_libs issue for pg 9.5.5 when `/data/src` folder doesn't exist

### DIFF
--- a/cookbooks/db_client_libs/recipes/default.rb
+++ b/cookbooks/db_client_libs/recipes/default.rb
@@ -17,73 +17,73 @@ install_packages=[
 if ['app', 'app_master', 'util'].include?(node['instance_role'])
   install_packages.each do |package|
     major = "#{package[:version].split('.')[0]}.#{package[:version].split('.')[1]}"
-    
+
     if package[:version] != '9.5.5'
-    
+
       ey_cloud_report "Installing db_client_lib #{package[:server]}" do
         message "installing #{package[:server]}-#{package[:version]}"
       end
-      
-      
+
+
       if package[:server] == 'postgresql-server'
-        
+
         enable_package "dev-libs/ossp-uuid" do
           version "1.6*"
         end
-        
+
         enable_package "dev-python/python-exec" do
           version '0.2'
           only_if { package[:version] >= '9.3' }
         end
-        
+
         enable_package "dev-db/postgresql-base" do
           version package[:version]
         end
-        
+
         enable_package "dev-db/postgresql-server" do
           version package[:version]
         end
-        
+
         package "dev-db/postgresql-server" do
           version package[:version]
           action :install
         end
-        
+
         execute "activate_postgres_#{major}" do
           command "eselect postgresql set #{major}"
           action :run
           only_if { package[:default_slot] }
         end
-        
+
       elsif package[:server] == 'percona-server'
-        
+
         unmask_path = "/etc/portage/package.unmask/mysql"
         unmask_body = "=virtual/mysql-5.6\n=dev-db/#{package[:server]}-#{package[:version]}"
-        
+
         update_file "unmasking #{package[:server]} #{package[:version]}" do
           action :append
           path unmask_path
           body unmask_body
           not_if "grep '#{unmask_body}' #{unmask_path}"
         end
-        
+
         enable_package "virtual/mysql" do
           version major
         end
-        
+
         enable_package "dev-db/#{package[:server]}" do
           version package[:version]
         end
-        
+
         enable_package "dev-util/cmake" do
           version '2.6.2'
         end
-        
+
         package "dev-db/#{package[:server]}" do
           version package[:version]
           action :install
         end
-      
+
       else
         ey_cloud_report "Installation of #{package[:server]}-#{package[:version]} failed:" do
           message "this server and version is unknown."
@@ -91,26 +91,27 @@ if ['app', 'app_master', 'util'].include?(node['instance_role'])
       end
 
     elsif package[:version] == '9.5.5' and (package[:server] == 'postgresql-server' or package[:server] == 'postgresql')
-      
+
       package[:server] = 'postgresql'
       srcdir = "/data/src/#{package[:server]}/"
       package_version = "#{package[:server]}-#{package[:version]}"
-      
+
       ey_cloud_report "Installing Postgres #{package[:version]} client" do
         message "installing #{package_version}"
       end
-      
+
       directory "#{srcdir}" do
+        recursive true
         owner 'root'
         group 'root'
         mode 0755
       end
-      
+
       remote_file "#{srcdir}/#{package_version}.tar.bz2" do
         source "https://ftp.postgresql.org/pub/source/v#{package[:version]}/#{package_version}.tar.bz2"
         notifies :run, "bash[install_#{package[:server]}]", :immediately
       end
-      
+
       bash "install_#{package[:server]}" do
         user "root"
         cwd "#{srcdir}"
@@ -127,20 +128,20 @@ if ['app', 'app_master', 'util'].include?(node['instance_role'])
           make -C src/include install
           make -C src/interfaces install
           make -C doc install
-          
+
         EOH
         action :nothing
       end
-        
+
       execute "activate_postgres_#{major}" do
         command "eselect postgresql set #{major}"
         action :run
         only_if { package[:default_slot] }
       end
     end
-    
+
   end
-  
+
   ey_cloud_report "Installation of db_client_libs" do
     message "complete!"
   end


### PR DESCRIPTION
## What

When using the `db_client_libs` recipe with pg 9.5.5 it was failing for instances that didn't have `/data/src` folder.

The issue was that it was trying to create a directory `/data/src/postgresql` but parent folder `/data/src` didn't exist.

To fix that we have used the `recursive true` option

The PR also strips non meaningful whitespace and fixes no new line at the end of file issue. To simplify review please add `?w=0` flag to the PR url like https://github.com/engineyard/ey-cloud-recipes/pull/314/files?w=0

## To test

1. Try to apply the cookbook on an instance without `/data/src` folder

**Current result:** It fails
**Expected result:** Recipe is applied successfully