### PR TITLE
DJ worker memory limit and other settings in attributes.

### DIFF
--- a/cookbooks/delayed_job4/README.markdown
+++ b/cookbooks/delayed_job4/README.markdown
@@ -15,6 +15,19 @@ To install this, you will need to add the following to cookbooks/main/recipes/de
 Make sure this and any customizations to the recipe are committed to your own fork of this
 repository.
 
+## Customizations
+
+Some common customizations can be made in `attributes/default.rb`.
+
+### Set the worker memory limit
+
+Monit keeps track of your DJ workers and by default, it restarts workers exceeding 300MB of memory.
+
+```ruby
+# specify custom memory limit
+default['delayed_job4']['worker_memory'] = 400
+```
+
 ## Restarting your workers
 
 This recipe does NOT restart your workers. The reason for this is that shipping your application and

--- a/cookbooks/delayed_job4/attributes/default.rb
+++ b/cookbooks/delayed_job4/attributes/default.rb
@@ -1,0 +1,16 @@
+# determine the number of workers to run based on instance size
+if node[:instance_role] == 'solo'
+  worker_count = 1
+else
+  case node[:ec2][:instance_type]
+  when 'm1.small' then worker_count = 2
+  when 'c1.medium' then worker_count = 4
+  when 'c1.xlarge' then worker_count = 8
+  else
+    worker_count = 2
+  end
+end
+
+default['delayed_job4']['is_dj_instance'] = node[:instance_role] == "solo" || (node[:instance_role] == "util" && node[:name] !~ /^(mongodb|redis|memcache)/)
+default['delayed_job4']['worker_count'] = worker_count
+default['delayed_job4']['worker_memory'] = 300

--- a/cookbooks/delayed_job4/recipes/default.rb
+++ b/cookbooks/delayed_job4/recipes/default.rb
@@ -3,7 +3,7 @@
 # Recipe:: default
 #
 
-if node[:instance_role] == "solo" || (node[:instance_role] == "util" && node[:name] !~ /^(mongodb|redis|memcache)/)
+if node['delayed_job4']['is_dj_instance']
   directory "/engineyard/custom" do
     owner "root"
     group "root"
@@ -18,21 +18,8 @@ if node[:instance_role] == "solo" || (node[:instance_role] == "util" && node[:na
   end
 
   node[:applications].each do |app_name,data|
-  
-    # determine the number of workers to run based on instance size
-    if node[:instance_role] == 'solo'
-      worker_count = 1
-    else
-      case node[:ec2][:instance_type]
-      when 'm1.small' then worker_count = 2
-      when 'c1.medium' then worker_count = 4
-      when 'c1.xlarge' then worker_count = 8
-      else 
-        worker_count = 2
-      end
-    end
     
-    worker_count.times do |count|
+    node['delayed_job4']['worker_count'].times do |count|
       template "/etc/monit.d/delayed_job#{count+1}.#{app_name}.monitrc" do
         source "dj.monitrc.erb"
         owner "root"
@@ -42,7 +29,8 @@ if node[:instance_role] == "solo" || (node[:instance_role] == "util" && node[:na
           :app_name => app_name,
           :user => node[:owner_name],
           :worker_name => "#{app_name}_delayed_job#{count+1}",
-          :framework_env => node[:environment][:framework_env]
+          :framework_env => node[:environment][:framework_env],
+          :worker_memory => node['delayed_job4']['worker_memory']
         })
       end
     end

--- a/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
@@ -2,5 +2,5 @@ check process <%= @worker_name %>
   with pidfile /var/run/engineyard/dj/<%= @app_name %>/dj_<%= @worker_name %>.pid
   start program = "/engineyard/custom/dj <%= @app_name %> start <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
   stop program = "/engineyard/custom/dj <%= @app_name %> stop <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
-  if totalmem is greater than 300 MB then restart # eating up memory?
+  if totalmem is greater than <%= @worker_memory %> MB then restart # eating up memory?
   group dj_<%= @app_name %>


### PR DESCRIPTION
Description of your patch
-------------

This change makes the DJ worker memory limit in the monit control file customizable through delayed_job4/attributes/default.rb. Other settings (worker_count and is_dj_instance) were moved from delayed_job4/recipes/default.rb to delayed_job4/attributes/default.rb.

How to Test
-------------

Enable the updated delayed_job4 recipe, and try changing the value of `default['delayed_job4']['worker_memory']` in attributes/default.rb. Check that the memory limit in /etc/monit.d/delayed_job*.monitrc gets updated on Apply.

Also, try changing `default['delayed_job4']['is_dj_instance']` to only apply to solo:

```ruby
# comment out the rest of the condition
default['delayed_job4']['is_dj_instance'] = node[:instance_role] == "solo" #|| (node[:instance_role] == "util" && node[:name] !~ /^(mongodb|redis|memcache)/)
```

Then, if you try adding a utility instance to your environment, DJ should **not** get set up on the utility instance. Uncomment the rest of the condition to install DJ in utility instances. Try adding a utility instance that matches one of the names in the regex (mongodb, redis or memcache). DJ should **not** get set up on that utility instance. If you remove the name from the regex, and Apply, check that DJ is then setup.

To test the worker_count, you can try changing the worker_count value in the `else` condition in attributes/default.rb. The new worker count should get applied to your utility instances.

```ruby
if node[:instance_role] == 'solo'
  worker_count = 1
else
  case node[:ec2][:instance_type]
  [...redacted...]
  else
    worker_count = 2 # change this
  end
end
```

Or you can directly change the value in this line:

```
default['delayed_job4']['worker_count'] = worker_count
```
