### PR TITLE
DJ: Add default worker count for new instance types.

### DIFF
--- a/cookbooks/delayed_job4/attributes/default.rb
+++ b/cookbooks/delayed_job4/attributes/default.rb
@@ -1,15 +1,46 @@
 # determine the number of workers to run based on instance size
-if node[:instance_role] == 'solo'
-  worker_count = 1
-else
-  case node[:ec2][:instance_type]
-  when 'm1.small' then worker_count = 2
-  when 'c1.medium' then worker_count = 4
-  when 'c1.xlarge' then worker_count = 8
-  else
-    worker_count = 2
-  end
-end
+worker_count = if node[:instance_role] == 'solo'
+                 1
+               else
+                 case node[:ec2][:instance_type]
+                 when 't2.micro' then 1
+                 when 't2.small' then 1
+                 when 't2.xlarge' then 4
+                 when 't2.2xlarge' then 8
+                 when 'm3.large' then 4
+                 when 'm3.xlarge' then 8
+                 when 'm3.2xlarge' then 8
+                 when 'c3.large' then 4
+                 when 'c3.xlarge' then 8
+                 when 'c3.2xlarge' then 8
+                 when 'c3.4xlarge' then 16
+                 when 'c3.8xlarge' then 32
+                 when 'm4.large' then 4
+                 when 'm4.xlarge' then 8
+                 when 'm4.2xlarge' then 8
+                 when 'm4.4xlarge' then 16
+                 when 'm4.10xlarge' then 40
+                 when 'm4.16xlarge' then 64
+                 when 'c4.large' then 4
+                 when 'c4.xlarge' then 8
+                 when 'c4.2xlarge' then 8
+                 when 'c4.4xlarge' then 16
+                 when 'c4.8xlarge' then 32
+                 when 'r3.large' then 4
+                 when 'r3.xlarge' then 8
+                 when 'r3.2xlarge' then 16
+                 when 'r3.4xlarge' then 32
+                 when 'r3.8xlarge' then 64
+                 when 'r4.large' then 4
+                 when 'r4.xlarge' then 8
+                 when 'r4.2xlarge' then 16
+                 when 'r4.4xlarge' then 32
+                 when 'r4.8xlarge' then 64
+                 when 'r4.16xlarge' then 128
+                 else # default
+                   2
+                 end
+               end
 
 default['delayed_job4']['is_dj_instance'] = node[:instance_role] == "solo" || (node[:instance_role] == "util" && node[:name] !~ /^(mongodb|redis|memcache)/)
 default['delayed_job4']['worker_count'] = worker_count


### PR DESCRIPTION
Description of your patch
-------------

Fixes #230. This change adds default values for worker count for additional, newer instance types.

How to Test
-------------

Use delayed_job4 custom chef recipe. Make sure is_dj_instance attribute uses default value that also sets up DJ in utility instances named "delayed_job". Try adding utility instances named "delayed_job" with various instance types (t2, r3, r4) and compare to the default values in delayed_job4/attributes/default.rb.
