### PR TITLE
Bugfix: Flume recipe: Use AWS instance id as agent name

### DIFF
--- a/cookbooks/flume/recipes/default.rb
+++ b/cookbooks/flume/recipes/default.rb
@@ -103,6 +103,7 @@ if ( ['app_master', 'app', 'solo'].include?(node[:instance_role]) )
     group node[:owner_name]
     mode 0644
     variables({
+      :instance_id => instance_id,
       :agent_id => unique_agent_id,
       :app_name => app_name,
       :app_logfile => app_logfile,

--- a/cookbooks/flume/templates/default/flume.conf.erb
+++ b/cookbooks/flume/templates/default/flume.conf.erb
@@ -1,15 +1,15 @@
-agent.sources = source<%= @agent_id %>
-agent.sinks = sink<%= @agent_id %>
-agent.channels = channel<%= @agent_id %>
+<%= @instance_id %>.sources = source<%= @agent_id %>
+<%= @instance_id %>.sinks = sink<%= @agent_id %>
+<%= @instance_id %>.channels = channel<%= @agent_id %>
 
-agent.sources.source<%= @agent_id %>.type = exec
-agent.sources.source<%= @agent_id %>.command = tail -F /data/<%= @app_name %>/shared/log/<%= @app_logfile %>
+<%= @instance_id %>.sources.source<%= @agent_id %>.type = exec
+<%= @instance_id %>.sources.source<%= @agent_id %>.command = tail -F /data/<%= @app_name %>/shared/log/<%= @app_logfile %>
 
-agent.sinks.sink<%= @agent_id %>.type = avro
-agent.sinks.sink<%= @agent_id %>.hostname = <%= @hostname %>
-agent.sinks.sink<%= @agent_id %>.port = <%= @port %>
+<%= @instance_id %>.sinks.sink<%= @agent_id %>.type = avro
+<%= @instance_id %>.sinks.sink<%= @agent_id %>.hostname = <%= @hostname %>
+<%= @instance_id %>.sinks.sink<%= @agent_id %>.port = <%= @port %>
 
-agent.channels.channel<%= @agent_id %>.type = memory
+<%= @instance_id %>.channels.channel<%= @agent_id %>.type = memory
 
-agent.sources.source<%= @agent_id %>.channels = channel<%= @agent_id %>
-agent.sinks.sink<%= @agent_id %>.channel= channel<%= @agent_id %>
+<%= @instance_id %>.sources.source<%= @agent_id %>.channels = channel<%= @agent_id %>
+<%= @instance_id %>.sinks.sink<%= @agent_id %>.channel= channel<%= @agent_id %>


### PR DESCRIPTION
The agent name in the configuration should be the same as the agent name used by the start script (https://github.com/engineyard/ey-cloud-recipes/blob/master/cookbooks/flume/templates/default/flume-start.sh.erb)