### PR TITLE
changing logentries to rapid7 on ebuild file

### DIFF
--- a/cookbooks/le/files/default/le-1.4.25.ebuild
+++ b/cookbooks/le/files/default/le-1.4.25.ebuild
@@ -13,7 +13,7 @@ AUTHOR=logentries
 
 SRC_URI="https://github.com/logentries/le/tarball/v${PV} -> $P.tar.gz"
 REVISION="b4cb54d"
-S="${WORKDIR}/logentries-le-${REVISION}"
+S="${WORKDIR}/rapid7-le-${REVISION}"
 BUILD_DIR="${S}"
 KEYWORDS="x86 amd64 mips ~ppc ~ppc-macos -ia64"
 USE=""


### PR DESCRIPTION
#### Description of your patch
Changing "logentries" to "rapid7" on ebuild file

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
files/default/le-1.4.25.ebuild

#### Description of testing done
See QA instructions

#### QA Instructions
No QA needed
