### PR TITLE
Fix Jetty version for Jenkins recibe

### DIFF
--- a/cookbooks/jenkins/recipes/jetty_install.rb
+++ b/cookbooks/jenkins/recipes/jetty_install.rb
@@ -11,12 +11,12 @@ remote_file "/etc/monit.d/jetty.monitrc" do
 end
 
 execute "Install Jetty" do
-  command "tar -zxvf /tmp/jetty.tar.gz jetty-distribution-8.1.16.v20140903/"
+  command "tar -zxvf /tmp/jetty.tar.gz jetty-distribution-8.1.17.v20150415/"
   cwd "/data/"
 end
 
 execute "symlink Jetty" do
-  command "sudo ln -fs /data/jetty-distribution-8.1.16.v20140903 /opt/jetty"
+  command "sudo ln -fs /data/jetty-distribution-8.1.17.v20150415 /opt/jetty"
 end
 
 execute "symlink initscript" do


### PR DESCRIPTION
# Description of your patch
Fix Jetty version for Jenkins, the currently recipe is not being successfully when applied.

# Estimated risk
Low

# Components involved
Jenkins recipe