### PR TITLE
Update sidekiq readme.md

### DIFF
--- a/cookbooks/sidekiq/readme.md
+++ b/cookbooks/sidekiq/readme.md
@@ -95,9 +95,9 @@ Stop sidekiq at the start of the deploy in `deploy/before_bundle.rb`:
 
 ```
 on_utilities("sidekiq") do
+  sudo "monit stop all -g #{config.app}_sidekiq"
   worker_count = 1 # change as needed
-  (0...worker_count).each do |i|
-    sudo "monit stop all -g #{config.app}_sidekiq"
+  (0...worker_count).each do |i|    
     sudo "/engineyard/bin/sidekiq #{config.app} stop #{config.framework_env} #{i}"
   end
 end
@@ -119,9 +119,9 @@ Stop sidekiq at the start of the deploy in `deploy/before_bundle.rb`:
 
 ```
 on_app_servers do
+  sudo "monit stop all -g #{config.app}_sidekiq"
   worker_count = 1 # change as needed
   (0...worker_count).each do |i|
-    sudo "monit stop all -g #{config.app}_sidekiq"
     sudo "/engineyard/bin/sidekiq #{config.app} stop #{config.framework_env} #{i}"
   end
 end


### PR DESCRIPTION
The `monit stop` should be outside the worker loop. It only needs to be called once as it already restarts everything belonging to the #{config.app}_sidekiq group.

If `monit stop` inside the loop we'll get `monit: action failed -- Other action already in progress -- please try again later` errors during deploy.