### PR TITLE
Sidekiq: Remove monit restart in sidekiq::setup

### DIFF
--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -21,12 +21,7 @@ if util_or_app_server?(node[:sidekiq][:utility_name])
 
   # loop through applications
   node[:applications].each do |app_name, _|
-    # reload monit
-    execute "restart-sidekiq-for-#{app_name}" do
-      command "monit reload && sleep 10 && monit restart all -g #{app_name}_sidekiq"
-      action :nothing
-    end
-    
+
     # monit
     template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
       mode 0644 
@@ -38,7 +33,6 @@ if util_or_app_server?(node[:sidekiq][:utility_name])
         :rails_env => node[:environment][:framework_env],
         :memory_limit => node[:sidekiq][:worker_memory] # MB
       })
-      notifies :run, resources(:execute => "restart-sidekiq-for-#{app_name}")
     end
     
     # database.yml
@@ -47,7 +41,6 @@ if util_or_app_server?(node[:sidekiq][:utility_name])
       command "sed -ibak --follow-symlinks 's/reconnect/pool:      #{node[:sidekiq][:concurrency]}\\\n  reconnect/g' #{db_yaml_file}"
       action :run
       only_if "test -f #{db_yaml_file} && ! grep 'pool: *#{node[:sidekiq][:concurrency]}' #{db_yaml_file}"
-      notifies :run, resources(:execute => "restart-sidekiq-for-#{app_name}")
     end
 
     # yml files
@@ -59,8 +52,7 @@ if util_or_app_server?(node[:sidekiq][:utility_name])
         source "sidekiq.yml.erb"
         backup false
         variables(node[:sidekiq])
-        notifies :run, resources(:execute => "restart-sidekiq-for-#{app_name}")
       end
     end
-  end 
+  end
 end


### PR DESCRIPTION
This part is prone to timing errors, causing chef failures
and sidekiq::cleanup already restarts sidekiq even without the monit reload and restart