### PR TITLE
Fixes eybackup_slave recipe db_stack_name

### DIFF
--- a/cookbooks/eybackup_slave/recipes/default.rb
+++ b/cookbooks/eybackup_slave/recipes/default.rb
@@ -11,7 +11,7 @@ end
 
 # database is mysql? (EY Cloud already sets up eybackup on the slave for postgres)
 env = node[:engineyard][:environment]
-stack = env[:db_stack_name][/mysql|postgresql/]
+stack = env[:db_stack_name][/postgres[_0-9]*/] ? 'postgresql' : env[:db_stack_name][/mysql|postgresql/]
 
 # find database slave node
 db_slave = env[:instances].find{|i| i[:role][/db_slave/]}


### PR DESCRIPTION
 I appplied this recipe on an environment I manage on Engine Yard, but the `env[:db_stack_name]` had a value of  `'postgres9_4'`, effectively setting the `stack` variable to an empty string, resulting in the cronjob not running.

```
 sudo grep 'db_stack_name' /etc/chef-custom/dna.json 
      "db_stack_name": "postgres9_4",
```