### PR TITLE
Custom nodejs recipe

### DIFF
--- a/cookbooks/custom_nodejs/README.md
+++ b/cookbooks/custom_nodejs/README.md
@@ -16,5 +16,5 @@ repository.
 
 ## Customizations
 
-The version of Node.js to be install can be set in `attributes/default.rb`. You can check the available versions [here](https://nodejs.org/en/download/releases/). 
+The version of Node.js to be install can be set in `attributes/default.rb`. Please avoid installing the same versions already existing in portage (check via `eix nodejs`). You can check the available versions [here](https://nodejs.org/en/download/releases/). 
 

--- a/cookbooks/custom_nodejs/README.md
+++ b/cookbooks/custom_nodejs/README.md
@@ -3,7 +3,7 @@
 This cookbook can serve as a good starting point for upgrading Node.js in your instances.
 Specifically, it gives you the tools in order to install versions of nodejs that are not present in the portage tree.
 
-** Please Note ** This recipe will setup the selected version of Node.js (the version specified in attributes) in all instances by default. If you need custom_nodejs to run only in app/util, you will need to modify the recipe.
+** Please Note ** This recipe will setup the selected version of Node.js (the version specified in attributes) in all instances by default. If you need custom_nodejs to run only in app/util, you will need to modify the recipe. Also, since this recipe is practically installing node versions not officially supported by portage, integration is not guaranteed.  
 
 ## Installation
 

--- a/cookbooks/custom_nodejs/README.md
+++ b/cookbooks/custom_nodejs/README.md
@@ -1,0 +1,20 @@
+# Custom Node.js
+
+This cookbook can serve as a good starting point for upgrading Node.js in your instances.
+Specifically, it gives you the tools in order to install versions of nodejs that are not present in the portage tree.
+
+** Please Note ** This recipe will setup the selected version of Node.js (the version specified in attributes) in all instances by default. If you need custom_nodejs to run only in app/util, you will need to modify the recipe.
+
+## Installation
+
+To install this, you will need to add the following to cookbooks/main/recipes/default.rb:
+
+    include_recipe "custom_nodejs"
+
+Make sure this and any customizations to the recipe are committed to your own fork of this
+repository.
+
+## Customizations
+
+The version of Node.js to be install can be set in `attributes/default.rb`. You can check the available versions [here](https://nodejs.org/en/download/releases/). 
+

--- a/cookbooks/custom_nodejs/attributes/default.rb
+++ b/cookbooks/custom_nodejs/attributes/default.rb
@@ -1,0 +1,2 @@
+# set the custom node version ot install
+default[:custom_node_version] = "10.12.0"

--- a/cookbooks/custom_nodejs/files/default/nodejs-bin-generic.ebuild
+++ b/cookbooks/custom_nodejs/files/default/nodejs-bin-generic.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=4
+
+inherit pax-utils versionator
+
+DESCRIPTION="Ebuild for static binary build of nodejs"
+HOMEPAGE="http://nodejs.org"
+SRC_URI="http://nodejs.org/dist/v${PV}/node-v${PV}-linux-x64.tar.gz"
+
+LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
+SLOT="$(get_version_component_range 1-3)"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="app-admin/eselect-nodejs"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/node-v${PV}-linux-x64"
+INSTALL_DIR="/opt/nodejs/${PV}"
+
+src_install() {
+
+        # Installation of node modules
+        # doins is not used here since it uses a very
+        # basic install command which doen't keep binary permissions
+        # mkdir is needed as copy doesn't directly deal with the
+        # various ebuild helper functions
+        mkdir -p "${D}/${INSTALL_DIR}"
+        cp -a "${S}/lib" "${D}/${INSTALL_DIR}/"
+
+        # Install of node header files with symlinks from
+        # source node ebuild
+        insinto ${INSTALL_DIR}/include
+        doins -r include/node
+
+        dodir ${INSTALL_DIR}/include/node/deps/{v8,uv}
+        dosym . ${INSTALL_DIR}/include/node/src
+        for var in deps/{uv,v8}/include; do
+                dosym ../.. ${INSTALL_DIR}/include/node/${var}
+        done
+
+        # Man install
+        insinto ${INSTALL_DIR}/
+        doins -r share
+
+        # Node needs pax marking
+        into ${INSTALL_DIR}/
+        pax-mark -m bin/node
+        dobin bin/node
+        dosym ${INSTALL_DIR}/bin/node ${INSTALL_DIR}/bin/node-waf
+
+        # Symlink for npm + execute permissions
+        fperms 0755 ${INSTALL_DIR}/lib/node_modules/npm/bin/npm-cli.js
+        dosym ${INSTALL_DIR}/lib/node_modules/npm/bin/npm-cli.js \
+                ${INSTALL_DIR}/bin/npm
+}

--- a/cookbooks/custom_nodejs/recipes/default.rb
+++ b/cookbooks/custom_nodejs/recipes/default.rb
@@ -1,0 +1,48 @@
+version = node[:custom_node_version].strip
+
+ey_cloud_report "Install node-v#{version}" do
+  message "Installing custom node-v#{version}"
+end
+
+Chef::Log.info "Installing custom node-v#{version}"
+
+ebuild_file = "/engineyard/portage/engineyard/net-libs/nodejs-bin/nodejs-bin-#{version}.ebuild"
+
+#create the new nodejs ebuild
+remote_file ebuild_file do
+  source "nodejs-bin-generic.ebuild"
+  backup 0
+  mode 0644
+end
+
+#create the manifest file
+execute "ebuild-nodejs" do
+  cwd "/engineyard/portage/engineyard/net-libs/nodejs-bin/"
+  command "ebuild #{File.basename(ebuild_file)} manifest"
+end
+
+
+execute "eix-sync" do
+  command "eix-sync"
+end
+
+#inform the OS of the new package
+execute "egencache + eix-update" do
+    command "egencache --repo engineyard --update && eix-update"
+end
+
+#unmask the new node package
+enable_package "net-libs/nodejs-bin" do
+    version "#{version}"
+end
+
+#install the new node package
+package "net-libs/nodejs-bin" do
+    version version "#{version}"
+    action :install
+end
+
+#select the new node version
+execute "eselect nodejs-bin-#{version}" do
+  command "eselect nodejs set #{version}"
+end

--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -198,3 +198,6 @@
 
 #uncomment to include the classiclink recipe
 #include_recipe "classiclink"
+
+#uncomment to include the custom_nodejs recipe
+#include_recipe "custom_nodejs"


### PR DESCRIPTION
#### Description of your patch
This custom recipe installs nodejs of the selected version, even if this version does not exist in portage.

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
README

#### Description of testing done
In a v4 stack environment the recipe "custom_nodejs" was applied (for node-v10.12.0). The result was:

```
ip-10-0-0-77 ~ # node -v
v10.12.0
ip-10-0-0-77 ~ # npm -v
6.4.1

```

#### QA Instructions
1. select the nodejs version to install in `attributes/default.rb`. Do not use an already existing version in portage, as it will just fail. 
2. uncomment the line `include_recipe "custom_nodejs"` in `main/recipes/default.rb` in order to include the "custom_nodejs" recipe in the chef run
3. upload and apply the recipes in your v4 environment
4. check the version of nodejs via `node-v`, `eselect nodejs list` and `eix net-libs/nodejs-bin`