### PR TITLE
Fail2ban address typo on default.rb and added missing action on nginx-dos jail

### DIFF
--- a/cookbooks/fail2ban/attributes/default.rb
+++ b/cookbooks/fail2ban/attributes/default.rb
@@ -210,7 +210,8 @@ default['fail2ban']['jails'] = {
 				'logpath'   => '/var/log/nginx/*access.log',
 				'maxretry'  => '240',
 				'findtime'  => 60,
-				'bantime'   => 172800
+				'bantime'   => 172800,
+				'action'    => 'iptables-multiport[name=NoDos, port="http,https"]'
 			}
 		},
         'postfix'  => {

--- a/cookbooks/fail2ban/recipes/default.rb
+++ b/cookbooks/fail2ban/recipes/default.rb
@@ -37,7 +37,7 @@ fail2ban_replace_line "fail2ban conf socket" do
     path     "/etc/fail2ban/fail2ban.conf"
 end
 
-file_replace_line "fail2ban conf pidfile" do
+fail2ban_replace_line "fail2ban conf pidfile" do
     replace  "pidfile="
     with     "pidfile=#{node['fail2ban']['pidfile']}"
     path     "/etc/fail2ban/fail2ban.conf"


### PR DESCRIPTION
#### Description of your patch
Corrected a typo on /recipes/default.rb
Added missing action on /attributes/default.rb for nginx-dos

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
/recipes/default.rb
/attributes/default.rb

#### Description of testing done
See QA instructions

#### QA Instructions
No QA needed